### PR TITLE
54 assort export annotations

### DIFF
--- a/src/gdext.nim
+++ b/src/gdext.nim
@@ -1,8 +1,8 @@
 import gdextcore/dirty/gdextensioninterface
 export InitializationLevel, gdcall
 
-import gdextcore/[ staticevents, builtinindex, geometrics, gdvariant ]
-export             staticevents, builtinindex, geometrics, gdvariant
+import gdextcore/[ staticevents, builtinindex, geometrics, gdvariant, gdtypedarray ]
+export             staticevents, builtinindex, geometrics, gdvariant, gdtypedarray
 
 import gdextgen/[ builtinclasses, classindex, globalenums, localenums, structs ]
 export            builtinclasses, classindex, globalenums, localenums, structs

--- a/src/gdext/classautomate.nim
+++ b/src/gdext/classautomate.nim
@@ -110,6 +110,13 @@ export properties.`@export_file`
 export properties.`@export_global_file`
 export properties.`@export_enum`
 export properties.`@export_flags`
+export properties.`@export_flags_2d_navigation`
+export properties.`@export_flags_2d_physics`
+export properties.`@export_flags_2d_render`
+export properties.`@export_flags_3d_navigation`
+export properties.`@export_flags_3d_physics`
+export properties.`@export_flags_3d_render`
+export properties.`@export_flags_avoidance`
 export properties.`@export_exp_easing`
 export properties.`@export_multiline`
 export properties.`@export_node_path`

--- a/src/gdext/classautomate.nim
+++ b/src/gdext/classautomate.nim
@@ -97,6 +97,7 @@ template name*(newname: string) {.pragma.}
 export signals.signal
 export properties.register_property
 export properties.`@export`
+export properties.`@export_category`
 export properties.`@export_custom`
 
 macro gdsync*(body): untyped =

--- a/src/gdext/classautomate.nim
+++ b/src/gdext/classautomate.nim
@@ -111,6 +111,7 @@ export properties.`@export_global_file`
 export properties.`@export_enum`
 export properties.`@export_exp_easing`
 export properties.`@export_multiline`
+export properties.`@export_node_path`
 export properties.`@export_range`
 export properties.`@export_storage`
 

--- a/src/gdext/classautomate.nim
+++ b/src/gdext/classautomate.nim
@@ -100,7 +100,7 @@ export properties.RangeArgument
 export properties.`@export`
 export properties.`@export_category`
 export properties.`@export_group`
-export properties.`@export_sub_group`
+export properties.`@export_subgroup`
 export properties.`@export_custom`
 export properties.`@export_dir`
 export properties.`@export_global_dir`

--- a/src/gdext/classautomate.nim
+++ b/src/gdext/classautomate.nim
@@ -99,6 +99,8 @@ export properties.register_property
 export properties.RangeArgument
 export properties.`@export`
 export properties.`@export_category`
+export properties.`@export_group`
+export properties.`@export_sub_group`
 export properties.`@export_custom`
 export properties.`@export_dir`
 export properties.`@export_global_dir`

--- a/src/gdext/classautomate.nim
+++ b/src/gdext/classautomate.nim
@@ -109,6 +109,7 @@ export properties.`@export_global_dir`
 export properties.`@export_file`
 export properties.`@export_global_file`
 export properties.`@export_enum`
+export properties.`@export_flags`
 export properties.`@export_exp_easing`
 export properties.`@export_multiline`
 export properties.`@export_node_path`

--- a/src/gdext/classautomate.nim
+++ b/src/gdext/classautomate.nim
@@ -96,10 +96,12 @@ else:
 template name*(newname: string) {.pragma.}
 export signals.signal
 export properties.register_property
+export properties.RangeArgument
 export properties.`@export`
 export properties.`@export_category`
 export properties.`@export_custom`
 export properties.`@export_multiline`
+export properties.`@export_range`
 export properties.`@export_storage`
 
 macro gdsync*(body): untyped =

--- a/src/gdext/classautomate.nim
+++ b/src/gdext/classautomate.nim
@@ -96,6 +96,7 @@ else:
 template name*(newname: string) {.pragma.}
 export signals.signal
 export properties.register_property
+export properties.ExpEasingArgument
 export properties.RangeArgument
 export properties.`@export`
 export properties.`@export_category`
@@ -108,6 +109,7 @@ export properties.`@export_global_dir`
 export properties.`@export_file`
 export properties.`@export_global_file`
 export properties.`@export_enum`
+export properties.`@export_exp_easing`
 export properties.`@export_multiline`
 export properties.`@export_range`
 export properties.`@export_storage`

--- a/src/gdext/classautomate.nim
+++ b/src/gdext/classautomate.nim
@@ -11,7 +11,10 @@ import gdextcore/commandindex
 import gdextcore/builtinindex
 import gdextcore/extracommands
 import gdextcore/gdclass
+import gdextgen/globalenums
 import gdext/classtraits
+
+export globalenums.PropertyUsageFlags
 
 proc create_bind(T: typedesc[SomeUserClass]): ObjectPtr =
   let class = instantiate_internal T
@@ -91,9 +94,10 @@ else:
     )
 
 template name*(newname: string) {.pragma.}
-template getter*(newname: string) {.pragma.}
-template setter*(newname: string) {.pragma.}
 export signals.signal
+export properties.register_property
+export properties.`@export`
+export properties.`@export_custom`
 
 macro gdsync*(body): untyped =
   case body.kind
@@ -115,5 +119,4 @@ proc register*(T: typedesc) =
     interface_ClassDB_registerExtensionClass(environment.library, addr className(T), addr className(T.Super), addr info)
   else:
     interface_ClassDB_registerExtensionClass2(environment.library, addr className(T), addr className(T.Super), addr info)
-  sync_property(T)
   invoke contract(T)

--- a/src/gdext/classautomate.nim
+++ b/src/gdext/classautomate.nim
@@ -100,6 +100,10 @@ export properties.RangeArgument
 export properties.`@export`
 export properties.`@export_category`
 export properties.`@export_custom`
+export properties.`@export_dir`
+export properties.`@export_global_dir`
+export properties.`@export_file`
+export properties.`@export_global_file`
 export properties.`@export_multiline`
 export properties.`@export_range`
 export properties.`@export_storage`

--- a/src/gdext/classautomate.nim
+++ b/src/gdext/classautomate.nim
@@ -101,6 +101,7 @@ export properties.`@export`
 export properties.`@export_category`
 export properties.`@export_group`
 export properties.`@export_subgroup`
+export properties.`@export_color_no_alpha`
 export properties.`@export_custom`
 export properties.`@export_dir`
 export properties.`@export_global_dir`

--- a/src/gdext/classautomate.nim
+++ b/src/gdext/classautomate.nim
@@ -107,6 +107,7 @@ export properties.`@export_dir`
 export properties.`@export_global_dir`
 export properties.`@export_file`
 export properties.`@export_global_file`
+export properties.`@export_enum`
 export properties.`@export_multiline`
 export properties.`@export_range`
 export properties.`@export_storage`

--- a/src/gdext/classautomate.nim
+++ b/src/gdext/classautomate.nim
@@ -99,6 +99,7 @@ export properties.register_property
 export properties.`@export`
 export properties.`@export_category`
 export properties.`@export_custom`
+export properties.`@export_storage`
 
 macro gdsync*(body): untyped =
   case body.kind

--- a/src/gdext/classautomate.nim
+++ b/src/gdext/classautomate.nim
@@ -112,6 +112,7 @@ export properties.`@export_enum`
 export properties.`@export_exp_easing`
 export properties.`@export_multiline`
 export properties.`@export_node_path`
+export properties.`@export_placeholder`
 export properties.`@export_range`
 export properties.`@export_storage`
 

--- a/src/gdext/classautomate.nim
+++ b/src/gdext/classautomate.nim
@@ -99,6 +99,7 @@ export properties.register_property
 export properties.`@export`
 export properties.`@export_category`
 export properties.`@export_custom`
+export properties.`@export_multiline`
 export properties.`@export_storage`
 
 macro gdsync*(body): untyped =

--- a/src/gdext/classautomate/procs.nim
+++ b/src/gdext/classautomate/procs.nim
@@ -10,7 +10,10 @@ import methodinfo
 import propertyinfo
 import checkform
 
-macro registerProc(procdef): untyped =
+macro registerProc*(procdef): untyped =
+  let procdef =
+    if procdef.kind == nnkProcDef: procdef
+    else: procdef.getImpl
   let name = procdef.name
   let arg0_T = procdef.params[1][1]
 
@@ -27,7 +30,7 @@ macro registerProc(procdef): untyped =
   let methodinfoDef = procdef.classMethodInfo(gdname)
 
   quote do:
-    process(contract(`arg0T`).procedure, `gdname`):
+    process(contract(typedesc `arg0T`).procedure, `gdname`):
       let glue = `methodinfoDef`
       interface_ClassDB_registerExtensionClassMethod(environment.library, addr className(typedesc `arg0_T`), addr glue.info)
 

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -72,6 +72,19 @@ template `@export_category`*(name: StringName): untyped =
       addr className(PropTestNode), native info,
       addr setter, addr getter)
 
+template `@export_group`*[T: SomeUserClass](typ: typedesc[T]; name: String; prefix: String = gdstring""): untyped =
+  process(typ.contract.property, "group " & $name):
+    let n = name
+    let p = prefix
+    interface_ClassDB_registerExtensionClassPropertyGroup(environment.library,
+      addr className(typ), addr n, addr p)
+template `@export_sub_group`*[T: SomeUserClass](typ: typedesc[T]; name: String; prefix: String = gdstring""): untyped =
+  process(typ.contract.property, "sub group " & $name):
+    let n = name
+    let p = prefix
+    interface_ClassDB_registerExtensionClassPropertySubGroup(environment.library,
+      addr className(typ), addr n, addr p)
+
 template `@export_custom`*[T: SomeUserClass; S: SomeProperty](
       name: StringName;
       getter: proc(self: T): S;

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -139,6 +139,18 @@ template `@export_global_file`*[T: SomeUserClass; S: SomeProperty](
     getter.gdname, setter.gdname,
     hint= propertyHintGlobalFile)
 
+template `@export_enum`*[T: SomeUserClass; S: SomeProperty](
+      name: StringName;
+      getter: proc(self: T): S;
+      setter: proc(self: T; value: S);
+      enums: varargs[string];
+    ): untyped =
+
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintEnum,
+    hint_string= @enums.join(","))
+
 template `@export_multiline`*[T: SomeUserClass; S: SomeProperty](
     name: StringName;
     getter: proc(self: T): S;

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -2,82 +2,65 @@ import gdextcore/utils/macros
 import gdextcore/commandindex
 import gdextcore/gdclass
 import gdextcore/staticevents
+import gdextcore/builtinindex
+import gdextgen/builtinclasses
+import gdextgen/globalenums
 
 import contracts
 import propertyinfo
 
-macro sync_property*(T: typedesc): untyped =
-  result = newStmtList()
-  for idef in T.typeDef.recList:
-    let info = gensym(nskLet, "info")
-    let typ = idef[1]
-    var nametag, gettertag, settertag: NimNode
+template register_property*(
+      typ: typedesc[SomeUserClass];
+      name: StringName;
+      proptyp: typedesc[SomeProperty];
+      getter, setter: StringName;
+      hint: PropertyHint = propertyHintNone;
+      hintstring: String = gdstring"";
+      usage: set[PropertyUsageFlags] = PropertyUsageFlags.propertyUsageDefault;
+    ): untyped =
 
-    case idef[0].kind
-    of nnkPragmaExpr:
-      let pragma = idef[0][1]
-      for expr in pragma:
-        case expr.kind
-        of nnkCall, nnkExprColonExpr:
-          case $expr[0]
-          of "name":
-            nametag = expr[1]
-          of "getter":
-            gettertag = expr[1]
-          of "setter":
-            settertag = expr[1]
-        else:
-          discard
+  process(typ.contract.property, $name):
+    let
+      info: ref PropertyInfoGlue = proptyp.propertyInfo(
+        name,
+        className typ,
+        hint,
+        hintstring,
+        usage)
+      setterName = setter
+      getterName = getter
+    interface_ClassDB_registerExtensionClassProperty( environment.library,
+      addr className(typ), native info,
+      addr setterName, addr getterName)
+
+macro gdname*(P: proc): string =
+  for pragma in P.getImpl.pragma:
+    case pragma.kind
+    of nnkExprColonExpr, nnkCall:
+      if pragma[0].eqIdent "name":
+        return pragma[1]
     else:
       discard
 
+  return newLit $P
 
-    if gettertag != nil or settertag != nil:
-      let
-        getter = genSym(nskLet, "getter")
-        setter = genSym(nskLet, "setter")
-        name =
-          if nametag == nil: newLit repr idef[0].basename
-          else: nametag
-        getterdef =
-          if gettertag == nil: quote do: (discard)
-          else: quote do:
-            let `getter` = stringname `gettertag`
-        getterref =
-          if gettertag == nil: quote do: nil
-          else: quote do: addr `getter`
-        setterdef =
-          if settertag == nil: quote do: (discard)
-          else: quote do:
-            let `setter` = stringname `settertag`
-        setterref =
-          if settertag == nil: quote do: nil
-          else: quote do: addr `setter`
+template `@export_custom`*[T: SomeUserClass; S: SomeProperty](
+      name: StringName;
+      getter: proc(self: T): S;
+      setter: proc(self: T; value: S);
+      hint: PropertyHint = propertyHintNone;
+      hintstring: String = gdstring"";
+      usage: set[PropertyUsageFlags] = PropertyUsageFlags.propertyUsageDefault;
+    ): untyped =
 
-      result.add quote do:
-        process(`T`.contract.property, `name`):
-          let `info`: ref PropertyInfoGlue = propertyInfo(typedesc `typ`, stringname `name`)
-          # `set_hint`
-          # `set_usage`
-          `getterdef`
-          `setterdef`
-          interface_ClassDB_registerExtensionClassProperty(environment.library, addr className(typedesc `T`), native `info`, `setterref`, `getterref`)
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname, hint, hintstring, usage)
 
-# macro property*(Class: typedesc[SomeUserClass]; name: string; `type`: typedesc; body) =
-#   var hint, usage: NimNode
-#   var set_hint = nnkDiscardStmt.newTree(newEmptyNode())
-#   var set_usage = nnkDiscardStmt.newTree(newEmptyNode())
-#   for tag in body:
-#     case tag.kind
-#     of nnkCall:
-#       case $tag[0]
-#       of "hint": hint = tag[1]
-#       of "usage": usage = tag[1]
-#     else:
-#       discard
-#   if hint != nil:
-#     set_hint = quote do:
-#       `glue`.hint = `hint`
-#   if usage != nil:
-#     set_usage = quote do:
-#       `glue`.usage = `usage`
+template `@export`*[T: SomeUserClass; S: SomeProperty](
+    name: StringName;
+    getter: proc(self: T): S;
+    setter: proc(self: T; value: S)): untyped =
+
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname)
+

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -195,6 +195,17 @@ macro `@export_node_path`*[T: SomeUserClass; S: SomeProperty](
   for valid in validTypes:
     result.add bindSym"$".newCall bindSym"className".newCall valid
 
+template `@export_placeholder`*[T: SomeUserClass; S: SomeProperty](
+    name: StringName;
+    getter: proc(self: T): S;
+    setter: proc(self: T; value: S);
+    placeholder: String): untyped =
+
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintPlaceholderText,
+    hint_string= placeholder)
+
 type RangeArgument* {.pure.} = enum
   or_less, or_greater, exp, radians_as_degrees, degrees, hide_slider
 template `@export_range`*[T: SomeUserClass; S: SomeProperty](

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -1,3 +1,4 @@
+import gdextcore/dirty/gdextensioninterface
 import gdextcore/utils/macros
 import gdextcore/commandindex
 import gdextcore/gdclass
@@ -64,3 +65,18 @@ template `@export`*[T: SomeUserClass; S: SomeProperty](
   register_property(typedesc T, name, typedesc S,
     getter.gdname, setter.gdname)
 
+template `@export_category`*(name: StringName): untyped =
+  process(PropTestNode.contract.property, "category " & $name):
+    let
+      info: ref PropertyInfoGlue = propertyInfo(
+        VariantType_Nil,
+        name,
+        stringName"",
+        propertyHintNone,
+        gdstring"",
+        {propertyUsageCategory})
+    let getter = stringName""
+    let setter = stringName""
+    interface_ClassDB_registerExtensionClassProperty( environment.library,
+      addr className(PropTestNode), native info,
+      addr setter, addr getter)

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -164,6 +164,76 @@ template `@export_flags`*[T: SomeUserClass; S: SomeProperty](
     hint= propertyHintFlags,
     hint_string= @flags.join(","))
 
+template `@export_flags_2d_navigation`*[T: SomeUserClass; S: SomeProperty](
+      name: StringName;
+      getter: proc(self: T): S;
+      setter: proc(self: T; value: S);
+    ): untyped =
+
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintLayers2dNavigation)
+
+template `@export_flags_2d_physics`*[T: SomeUserClass; S: SomeProperty](
+      name: StringName;
+      getter: proc(self: T): S;
+      setter: proc(self: T; value: S);
+    ): untyped =
+
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintLayers2dPhysics)
+
+template `@export_flags_2d_render`*[T: SomeUserClass; S: SomeProperty](
+      name: StringName;
+      getter: proc(self: T): S;
+      setter: proc(self: T; value: S);
+    ): untyped =
+
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintLayers2dRender)
+
+template `@export_flags_3d_navigation`*[T: SomeUserClass; S: SomeProperty](
+      name: StringName;
+      getter: proc(self: T): S;
+      setter: proc(self: T; value: S);
+    ): untyped =
+
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintLayers3dNavigation)
+
+template `@export_flags_3d_physics`*[T: SomeUserClass; S: SomeProperty](
+      name: StringName;
+      getter: proc(self: T): S;
+      setter: proc(self: T; value: S);
+    ): untyped =
+
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintLayers3dPhysics)
+
+template `@export_flags_3d_render`*[T: SomeUserClass; S: SomeProperty](
+      name: StringName;
+      getter: proc(self: T): S;
+      setter: proc(self: T; value: S);
+    ): untyped =
+
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintLayers3dRender)
+
+template `@export_flags_avoidance`*[T: SomeUserClass; S: SomeProperty](
+      name: StringName;
+      getter: proc(self: T): S;
+      setter: proc(self: T; value: S);
+    ): untyped =
+
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintLayersAvoidance)
+
 type ExpEasingArgument* = enum
   attenuation, positive_only
 template `@export_exp_easing`*[T: SomeUserClass; S: SomeProperty](

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -9,6 +9,7 @@ import gdextcore/staticevents
 import gdextcore/builtinindex
 import gdextgen/builtinclasses
 import gdextgen/globalenums
+import gdextgen/classindex
 
 import contracts
 import propertyinfo
@@ -173,6 +174,26 @@ template `@export_multiline`*[T: SomeUserClass; S: SomeProperty](
   register_property(typedesc T, name, typedesc S,
     getter.gdname, setter.gdname,
     hint= propertyHintMultilineText)
+
+template `@export_node_path`*[T: SomeUserClass; S: SomeProperty](
+    name: StringName;
+    getter: proc(self: T): S;
+    setter: proc(self: T; value: S);
+    validTypes: varargs[string]): untyped =
+
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintNodePathValidTypes,
+    hint_string= @validTypes.join(","))
+
+macro `@export_node_path`*[T: SomeUserClass; S: SomeProperty](
+    name: StringName;
+    getter: proc(self: T): S;
+    setter: proc(self: T; value: S);
+    validTypes: varargs[typedesc[Node]]): untyped =
+  result = bindSym"@export_node_path".newCall(name, getter, setter)
+  for valid in validTypes:
+    result.add bindSym"$".newCall bindSym"className".newCall valid
 
 type RangeArgument* {.pure.} = enum
   or_less, or_greater, exp, radians_as_degrees, degrees, hide_slider

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -81,6 +81,15 @@ template `@export_custom`*[T: SomeUserClass; S: SomeProperty](
   register_property(typedesc T, name, typedesc S,
     getter.gdname, setter.gdname, hint, hintstring, usage)
 
+template `@export_multiline`*[T: SomeUserClass; S: SomeProperty](
+    name: StringName;
+    getter: proc(self: T): S;
+    setter: proc(self: T; value: S)): untyped =
+
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintMultilineText)
+
 template `@export_storage`*[T: SomeUserClass; S: SomeProperty](
     name: StringName;
     getter: proc(self: T): S;

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -152,6 +152,18 @@ template `@export_enum`*[T: SomeUserClass; S: SomeProperty](
     hint= propertyHintEnum,
     hint_string= @enums.join(","))
 
+template `@export_flags`*[T: SomeUserClass; S: SomeProperty](
+      name: StringName;
+      getter: proc(self: T): S;
+      setter: proc(self: T; value: S);
+      flags: varargs[string];
+    ): untyped =
+
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintFlags,
+    hint_string= @flags.join(","))
+
 type ExpEasingArgument* = enum
   attenuation, positive_only
 template `@export_exp_easing`*[T: SomeUserClass; S: SomeProperty](

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -1,3 +1,6 @@
+from std/strutils import join
+from std/sequtils import concat, mapIt
+
 import gdextcore/dirty/gdextensioninterface
 import gdextcore/utils/macros
 import gdextcore/commandindex
@@ -89,6 +92,27 @@ template `@export_multiline`*[T: SomeUserClass; S: SomeProperty](
   register_property(typedesc T, name, typedesc S,
     getter.gdname, setter.gdname,
     hint= propertyHintMultilineText)
+
+type RangeArgument* {.pure.} = enum
+  or_less, or_greater, exp, radians_as_degrees, degrees, hide_slider
+template `@export_range`*[T: SomeUserClass; S: SomeProperty](
+    name: StringName;
+    getter: proc(self: T): S;
+    setter: proc(self: T; value: S);
+    min, max: S; extra: varargs[RangeArgument]): untyped =
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintRange,
+    hint_string= @[$min, $max].concat(@extra.mapit($it)).join(","))
+template `@export_range`*[T: SomeUserClass; S: SomeProperty](
+    name: StringName;
+    getter: proc(self: T): S;
+    setter: proc(self: T; value: S);
+    min, max, step: S; extra: varargs[RangeArgument]): untyped =
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintRange,
+    hint_string= @[$min, $max, $step].concat(@extra.mapIt($it)).join(","))
 
 template `@export_storage`*[T: SomeUserClass; S: SomeProperty](
     name: StringName;

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -129,7 +129,6 @@ template `@export_custom`*[T: SomeUserClass; S: SomeProperty](
       hintstring: String = gdstring"";
       usage: set[PropertyUsageFlags] = PropertyUsageFlags.propertyUsageDefault;
     ): untyped =
-
   register_property(typedesc T, name, typedesc S, getter, setter,
     hint, hintstring, usage)
 
@@ -182,7 +181,6 @@ template `@export_enum`*[T: SomeUserClass; S: SomeProperty](
       setter: proc(self: T; value: S);
       enums: varargs[string];
     ): untyped =
-
   register_property(typedesc T, name, typedesc S, getter, setter,
     hint= propertyHintEnum,
     hint_string= @enums.join(","))
@@ -193,7 +191,6 @@ template `@export_flags`*[T: SomeUserClass; S: SomeProperty](
       setter: proc(self: T; value: S);
       flags: varargs[string];
     ): untyped =
-
   register_property(typedesc T, name, typedesc S, getter, setter,
     hint= propertyHintFlags,
     hint_string= @flags.join(","))
@@ -203,7 +200,6 @@ template `@export_flags_2d_navigation`*[T: SomeUserClass; S: SomeProperty](
       getter: proc(self: T): S;
       setter: proc(self: T; value: S);
     ): untyped =
-
   register_property(typedesc T, name, typedesc S, getter, setter,
     hint= propertyHintLayers2dNavigation)
 
@@ -212,7 +208,6 @@ template `@export_flags_2d_physics`*[T: SomeUserClass; S: SomeProperty](
       getter: proc(self: T): S;
       setter: proc(self: T; value: S);
     ): untyped =
-
   register_property(typedesc T, name, typedesc S, getter, setter,
     hint= propertyHintLayers2dPhysics)
 
@@ -221,7 +216,6 @@ template `@export_flags_2d_render`*[T: SomeUserClass; S: SomeProperty](
       getter: proc(self: T): S;
       setter: proc(self: T; value: S);
     ): untyped =
-
   register_property(typedesc T, name, typedesc S, getter, setter,
     hint= propertyHintLayers2dRender)
 
@@ -239,7 +233,6 @@ template `@export_flags_3d_physics`*[T: SomeUserClass; S: SomeProperty](
       getter: proc(self: T): S;
       setter: proc(self: T; value: S);
     ): untyped =
-
   register_property(typedesc T, name, typedesc S, getter, setter,
     hint= propertyHintLayers3dPhysics)
 
@@ -248,7 +241,6 @@ template `@export_flags_3d_render`*[T: SomeUserClass; S: SomeProperty](
       getter: proc(self: T): S;
       setter: proc(self: T; value: S);
     ): untyped =
-
   register_property(typedesc T, name, typedesc S, getter, setter,
     hint= propertyHintLayers3dRender)
 
@@ -257,7 +249,6 @@ template `@export_flags_avoidance`*[T: SomeUserClass; S: SomeProperty](
       getter: proc(self: T): S;
       setter: proc(self: T; value: S);
     ): untyped =
-
   register_property(typedesc T, name, typedesc S, getter, setter,
     hint= propertyHintLayersAvoidance)
 
@@ -269,7 +260,6 @@ template `@export_exp_easing`*[T: SomeUserClass; S: SomeProperty](
       setter: proc(self: T; value: S);
       extra: varargs[ExpEasingArgument];
     ): untyped =
-
   register_property(typedesc T, name, typedesc S, getter, setter,
     hint= propertyHintExpEasing,
     hint_string= @extra.mapIt($it).join(","))
@@ -278,7 +268,6 @@ template `@export_multiline`*[T: SomeUserClass; S: SomeProperty](
     name: StringName;
     getter: proc(self: T): S;
     setter: proc(self: T; value: S)): untyped =
-
   register_property(typedesc T, name, typedesc S, getter, setter,
     hint= propertyHintMultilineText)
 
@@ -287,7 +276,6 @@ template `@export_node_path`*[T: SomeUserClass; S: SomeProperty](
     getter: proc(self: T): S;
     setter: proc(self: T; value: S);
     validTypes: varargs[string]): untyped =
-
   register_property(typedesc T, name, typedesc S, getter, setter,
     hint= propertyHintNodePathValidTypes,
     hint_string= @validTypes.join(","))
@@ -306,7 +294,6 @@ template `@export_placeholder`*[T: SomeUserClass; S: SomeProperty](
     getter: proc(self: T): S;
     setter: proc(self: T; value: S);
     placeholder: String): untyped =
-
   register_property(typedesc T, name, typedesc S, getter, setter,
     hint= propertyHintPlaceholderText,
     hint_string= placeholder)
@@ -334,6 +321,5 @@ template `@export_storage`*[T: SomeUserClass; S: SomeProperty](
     name: StringName;
     getter: proc(self: T): S;
     setter: proc(self: T; value: S)): untyped =
-
   register_property(typedesc T, name, typedesc S, getter, setter,
     usage= {propertyUsageStorage})

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -97,6 +97,15 @@ template `@export_custom`*[T: SomeUserClass; S: SomeProperty](
   register_property(typedesc T, name, typedesc S,
     getter.gdname, setter.gdname, hint, hintstring, usage)
 
+template `@export_color_no_alpha`*[T: SomeUserClass; S: SomeProperty](
+      name: StringName;
+      getter: proc(self: T): S;
+      setter: proc(self: T; value: S);
+    ): untyped =
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintColorNoAlpha)
+
 template `@export_dir`*[T: SomeUserClass; S: SomeProperty](
       name: StringName;
       getter: proc(self: T): S;

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -65,6 +65,15 @@ template `@export`*[T: SomeUserClass; S: SomeProperty](
   register_property(typedesc T, name, typedesc S,
     getter.gdname, setter.gdname)
 
+template `@export_storage`*[T: SomeUserClass; S: SomeProperty](
+    name: StringName;
+    getter: proc(self: T): S;
+    setter: proc(self: T; value: S)): untyped =
+
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    usage= {propertyUsageStorage})
+
 template `@export_category`*(name: StringName): untyped =
   process(PropTestNode.contract.property, "category " & $name):
     let

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -84,6 +84,39 @@ template `@export_custom`*[T: SomeUserClass; S: SomeProperty](
   register_property(typedesc T, name, typedesc S,
     getter.gdname, setter.gdname, hint, hintstring, usage)
 
+template `@export_dir`*[T: SomeUserClass; S: SomeProperty](
+      name: StringName;
+      getter: proc(self: T): S;
+      setter: proc(self: T; value: S);
+    ): untyped =
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintDir)
+template `@export_global_dir`*[T: SomeUserClass; S: SomeProperty](
+      name: StringName;
+      getter: proc(self: T): S;
+      setter: proc(self: T; value: S);
+    ): untyped =
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintGlobalDir)
+template `@export_file`*[T: SomeUserClass; S: SomeProperty](
+      name: StringName;
+      getter: proc(self: T): S;
+      setter: proc(self: T; value: S);
+    ): untyped =
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintFile)
+template `@export_global_file`*[T: SomeUserClass; S: SomeProperty](
+      name: StringName;
+      getter: proc(self: T): S;
+      setter: proc(self: T; value: S);
+    ): untyped =
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintGlobalFile)
+
 template `@export_multiline`*[T: SomeUserClass; S: SomeProperty](
     name: StringName;
     getter: proc(self: T): S;

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -45,18 +45,6 @@ macro gdname*(P: proc): string =
 
   return newLit $P
 
-template `@export_custom`*[T: SomeUserClass; S: SomeProperty](
-      name: StringName;
-      getter: proc(self: T): S;
-      setter: proc(self: T; value: S);
-      hint: PropertyHint = propertyHintNone;
-      hintstring: String = gdstring"";
-      usage: set[PropertyUsageFlags] = PropertyUsageFlags.propertyUsageDefault;
-    ): untyped =
-
-  register_property(typedesc T, name, typedesc S,
-    getter.gdname, setter.gdname, hint, hintstring, usage)
-
 template `@export`*[T: SomeUserClass; S: SomeProperty](
     name: StringName;
     getter: proc(self: T): S;
@@ -64,15 +52,6 @@ template `@export`*[T: SomeUserClass; S: SomeProperty](
 
   register_property(typedesc T, name, typedesc S,
     getter.gdname, setter.gdname)
-
-template `@export_storage`*[T: SomeUserClass; S: SomeProperty](
-    name: StringName;
-    getter: proc(self: T): S;
-    setter: proc(self: T; value: S)): untyped =
-
-  register_property(typedesc T, name, typedesc S,
-    getter.gdname, setter.gdname,
-    usage= {propertyUsageStorage})
 
 template `@export_category`*(name: StringName): untyped =
   process(PropTestNode.contract.property, "category " & $name):
@@ -89,3 +68,24 @@ template `@export_category`*(name: StringName): untyped =
     interface_ClassDB_registerExtensionClassProperty( environment.library,
       addr className(PropTestNode), native info,
       addr setter, addr getter)
+
+template `@export_custom`*[T: SomeUserClass; S: SomeProperty](
+      name: StringName;
+      getter: proc(self: T): S;
+      setter: proc(self: T; value: S);
+      hint: PropertyHint = propertyHintNone;
+      hintstring: String = gdstring"";
+      usage: set[PropertyUsageFlags] = PropertyUsageFlags.propertyUsageDefault;
+    ): untyped =
+
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname, hint, hintstring, usage)
+
+template `@export_storage`*[T: SomeUserClass; S: SomeProperty](
+    name: StringName;
+    getter: proc(self: T): S;
+    setter: proc(self: T; value: S)): untyped =
+
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    usage= {propertyUsageStorage})

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -151,6 +151,20 @@ template `@export_enum`*[T: SomeUserClass; S: SomeProperty](
     hint= propertyHintEnum,
     hint_string= @enums.join(","))
 
+type ExpEasingArgument* = enum
+  attenuation, positive_only
+template `@export_exp_easing`*[T: SomeUserClass; S: SomeProperty](
+      name: StringName;
+      getter: proc(self: T): S;
+      setter: proc(self: T; value: S);
+      extra: varargs[ExpEasingArgument];
+    ): untyped =
+
+  register_property(typedesc T, name, typedesc S,
+    getter.gdname, setter.gdname,
+    hint= propertyHintExpEasing,
+    hint_string= @extra.mapIt($it).join(","))
+
 template `@export_multiline`*[T: SomeUserClass; S: SomeProperty](
     name: StringName;
     getter: proc(self: T): S;

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -56,8 +56,8 @@ template `@export`*[T: SomeUserClass; S: SomeProperty](
   register_property(typedesc T, name, typedesc S,
     getter.gdname, setter.gdname)
 
-template `@export_category`*(name: StringName): untyped =
-  process(PropTestNode.contract.property, "category " & $name):
+template `@export_category`*[T: SomeUserClass](typ: typedesc[T]; name: StringName): untyped =
+  process(typ.contract.property, "category " & $name):
     let
       info: ref PropertyInfoGlue = propertyInfo(
         VariantType_Nil,
@@ -69,7 +69,7 @@ template `@export_category`*(name: StringName): untyped =
     let getter = stringName""
     let setter = stringName""
     interface_ClassDB_registerExtensionClassProperty( environment.library,
-      addr className(PropTestNode), native info,
+      addr className(typ), native info,
       addr setter, addr getter)
 
 template `@export_group`*[T: SomeUserClass](typ: typedesc[T]; name: String; prefix: String = gdstring""): untyped =

--- a/src/gdext/classautomate/properties.nim
+++ b/src/gdext/classautomate/properties.nim
@@ -78,8 +78,8 @@ template `@export_group`*[T: SomeUserClass](typ: typedesc[T]; name: String; pref
     let p = prefix
     interface_ClassDB_registerExtensionClassPropertyGroup(environment.library,
       addr className(typ), addr n, addr p)
-template `@export_sub_group`*[T: SomeUserClass](typ: typedesc[T]; name: String; prefix: String = gdstring""): untyped =
-  process(typ.contract.property, "sub group " & $name):
+template `@export_subgroup`*[T: SomeUserClass](typ: typedesc[T]; name: String; prefix: String = gdstring""): untyped =
+  process(typ.contract.property, "subgroup " & $name):
     let n = name
     let p = prefix
     interface_ClassDB_registerExtensionClassPropertySubGroup(environment.library,

--- a/src/gdext/classautomate/propertyinfo.nim
+++ b/src/gdext/classautomate/propertyinfo.nim
@@ -80,7 +80,7 @@ type SomeProperty* = concept type t
   t.variantType is VariantType
   t.uniqueUsage is set[PropertyUsageFlags]
 
-proc propertyInfo*[T: SomeProperty](_: typedesc[T];
+proc propertyInfo*(typ: VariantType;
       name: StringName = stringname"";
       class_name: StringName = stringname"";
       hint: PropertyHint = propertyHint_None;
@@ -88,10 +88,25 @@ proc propertyInfo*[T: SomeProperty](_: typedesc[T];
       usage: system.set[PropertyUsageFlags] = PropertyUsageFlags.propertyUsageDefault
     ): ref PropertyInfoGlue =
   (ref PropertyInfoGlue)(
-    type: T.variantType,
+    type: typ,
     name: new name,
     class_name: new class_name,
     hint: hint,
     hint_string: new hint_string,
-    usage: usage + T.uniqueUsage,
+    usage: usage,
+  )
+proc propertyInfo*[T: SomeProperty](_: typedesc[T];
+      name: StringName = stringname"";
+      class_name: StringName = stringname"";
+      hint: PropertyHint = propertyHint_None;
+      hint_string: String = gdstring"";
+      usage: system.set[PropertyUsageFlags] = PropertyUsageFlags.propertyUsageDefault
+    ): ref PropertyInfoGlue =
+  propertyInfo(
+    T.variantType,
+    name,
+    class_name,
+    hint,
+    hint_string,
+    usage + T.uniqueUsage,
   )

--- a/test/main.tscn
+++ b/test/main.tscn
@@ -14,4 +14,6 @@ script = ExtResource("1_x2b6x")
 [node name="Sprite2D" type="Sprite2D" parent="TesterNIM"]
 texture = ExtResource("2_p8ptw")
 
+[node name="PropTestNode" type="PropTestNode" parent="."]
+
 [connection signal="custom_signal" from="TesterNIM" to="TesterGD" method="_on_tester_nim_custom_signal"]

--- a/test/nim/bootstrap.nim
+++ b/test/nim/bootstrap.nim
@@ -8,6 +8,8 @@ import nimSideTester
 {.warning[UnusedImport]:off.}
 import geometrics
 import cases/use_api_from_toplevel
+import classes/gdproptestnode
+import classes/gdtestobject
 
 # ==================================
 
@@ -16,6 +18,8 @@ process initialize_scene:
   # register MyClass
   register GodotSideTester
   register NimSideTester
+  # register TestObject
+  register PropTestNode
 
   # ====================================
   discard

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -32,165 +32,144 @@ method init(self: PropTestNode) =
   self.PackedStringArray_with_export_multiline = packedStringArray()
   echo self.PackedStringArray_with_export_multiline.resize(1)
 
-proc string_with_export(self: PropTestNode): string {.gdsync, name: "get_string_with_export".} =
+`@export_category`PropTestNode, "Export Test"
+
+`@export`"string_with_export",
+    proc (self: PropTestNode): string = self.string_with_export,
+    proc (self: PropTestNode; value: string) = self.string_with_export = value
+
+proc get_string_with_export_through_proc(self: PropTestNode): string {.gdsync.} =
   self.string_with_export
-proc `string_with_export=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export".} =
+proc set_string_with_export_through_proc(self: PropTestNode; value: string) {.gdsync.} =
   self.string_with_export = value
+`@export`"string_with_export_through_proc",
+    get_string_with_export_through_proc,
+    set_string_with_export_through_proc
 
-proc string_with_export_placeholder(self: PropTestNode): string {.gdsync, name: "get_string_with_export_placeholder".} =
-  self.string_with_export_placeholder
-proc `string_with_export_placeholder=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_placeholder".} =
-  self.string_with_export_placeholder = value
+`@export_placeholder`"string_with_export_placeholder",
+    proc (self: PropTestNode): string = self.string_with_export_placeholder,
+    proc (self: PropTestNode; value: string) = self.string_with_export_placeholder = value,
+    "placeholder here..."
 
-proc string_with_export_dir(self: PropTestNode): string {.gdsync, name: "get_string_with_export_dir".} =
-  self.string_with_export_dir
-proc `string_with_export_dir=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_dir".} =
-  self.string_with_export_dir = value
-proc string_with_export_global_dir(self: PropTestNode): string {.gdsync, name: "get_string_with_export_global_dir".} =
-  self.string_with_export_global_dir
-proc `string_with_export_global_dir=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_global_dir".} =
-  self.string_with_export_global_dir = value
-proc string_with_export_file(self: PropTestNode): string {.gdsync, name: "get_string_with_export_file".} =
-  self.string_with_export_file
-proc `string_with_export_file=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_file".} =
-  self.string_with_export_file = value
-proc string_with_export_global_file(self: PropTestNode): string {.gdsync, name: "get_string_with_export_global_file".} =
-  self.string_with_export_global_file
-proc `string_with_export_global_file=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_global_file".} =
-  self.string_with_export_global_file = value
+`@export_group`PropTestNode, "filesystem"
 
-proc color_with_export(self: PropTestNode): Color {.gdsync, name: "get_color_with_export".} =
-  self.color_with_export
-proc `color_with_export=`(self: PropTestNode; value: Color) {.gdsync, name: "set_color_with_export".} =
-  self.color_with_export= value
-proc color_with_export_no_alpha(self: PropTestNode): Color {.gdsync, name: "get_color_with_export_no_alpha".} =
-  self.color_with_export_no_alpha
-proc `color_with_export_no_alpha=`(self: PropTestNode; value: Color) {.gdsync, name: "set_color_with_export_no_alpha".} =
-  self.color_with_export_no_alpha= value
+`@export_subgroup`ProptestNode, "local"
+`@export_dir`"string_with_export_dir",
+    proc (self: PropTestNode): string = self.string_with_export_dir,
+    proc (self: PropTestNode; value: string) = self.string_with_export_dir = value
+`@export_file`"string_with_export_file",
+    proc (self: PropTestNode): string = self.string_with_export_file,
+    proc (self: PropTestNode; value: string) = self.string_with_export_file = value
 
-proc int_with_export_enum(self: PropTestNode): int {.gdsync, name: "get_int_with_export_enum".} =
-  self.int_with_export_enum
-proc `int_with_export_enum=`(self: PropTestNode; value: int) {.gdsync, name: "set_int_with_export_enum".} =
-  self.int_with_export_enum = value
-proc string_with_export_enum(self: PropTestNode): string {.gdsync, name: "get_string_with_export_enum".} =
-  self.string_with_export_enum
-proc `string_with_export_enum=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_enum".} =
-  self.string_with_export_enum = value
+`@export_subgroup`ProptestNode, "global"
+`@export_global_dir`"string_with_export_global_dir",
+    proc (self: PropTestNode): string = self.string_with_export_global_dir,
+    proc (self: PropTestNode; value: string) = self.string_with_export_global_dir = value
+`@export_global_file`"string_with_export_global_file",
+    proc (self: PropTestNode): string = self.string_with_export_global_file,
+    proc (self: PropTestNode; value: string) = self.string_with_export_global_file = value
 
-proc int_with_export_flags(self: PropTestNode): int {.gdsync, name: "get_int_with_export_flags".} =
-  self.int_with_export_flags
-proc `int_with_export_flags=`(self: PropTestNode; value: int) {.gdsync, name: "set_int_with_export_flags".} =
-  self.int_with_export_flags = value
+`@export_group`PropTestNode, ""
+
+`@export`"color_with_export",
+    proc (self: PropTestNode): Color = self.color_with_export,
+    proc (self: PropTestNode; value: Color) = self.color_with_export = value
+`@export_color_no_alpha`"color_with_export_no_alpha",
+    proc (self: PropTestNode): Color = self.color_with_export_no_alpha,
+    proc (self: PropTestNode; value: Color) = self.color_with_export_no_alpha = value
+
+`@export_enum`"int_with_export_enum",
+    proc (self: PropTestNode): int = self.int_with_export_enum,
+    proc (self: PropTestNode; value: int) = self.int_with_export_enum = value,
+    "Alpha", "Beta:10", "Gamma"
+`@export_enum`"string_with_export_enum",
+    proc (self: PropTestNode): string = self.string_with_export_enum,
+    proc (self: PropTestNode; value: string) = self.string_with_export_enum = value,
+    "Alpha", "Beta", "Gamma"
+
+`@export_flags`"int_with_export_flags",
+    proc (self: PropTestNode): int = self.int_with_export_flags,
+    proc (self: PropTestNode; value: int) = self.int_with_export_flags = value,
+    "Alpha", "Beta", "Gamma"
 
 proc int_with_export_flags_some_layers(self: PropTestNode): int {.gdsync, name: "get_int_with_export_flags_some_layers".} =
   self.int_with_export_flags_some_layers
 proc `int_with_export_flags_some_layers=`(self: PropTestNode; value: int) {.gdsync, name: "set_int_with_export_flags_some_layers".} =
   self.int_with_export_flags_some_layers = value
 
+`@export_flags_2d_navigation`"int_with_export_flags_2d_navigation",
+    int_with_export_flags_some_layers,
+    `int_with_export_flags_some_layers=`
+`@export_flags_2d_physics`"int_with_export_flags_2d_physics",
+    int_with_export_flags_some_layers,
+    `int_with_export_flags_some_layers=`
+`@export_flags_2d_render`"int_with_export_flags_2d_render",
+    int_with_export_flags_some_layers,
+    `int_with_export_flags_some_layers=`
+`@export_flags_3d_navigation`"int_with_export_flags_3d_navigation",
+    int_with_export_flags_some_layers,
+    `int_with_export_flags_some_layers=`
+`@export_flags_3d_physics`"int_with_export_flags_3d_physics",
+    int_with_export_flags_some_layers,
+    `int_with_export_flags_some_layers=`
+`@export_flags_3d_render`"int_with_export_flags_3d_render",
+    int_with_export_flags_some_layers,
+    `int_with_export_flags_some_layers=`
+`@export_flags_avoidance`"int_with_export_flags_avoidance",
+    int_with_export_flags_some_layers,
+    `int_with_export_flags_some_layers=`
+
 proc float_with_export_exp_easing(self: PropTestNode): float {.gdsync, name: "get_float_with_export_exp_easing".} =
   self.float_with_export_exp_easing
 proc `float_with_export_exp_easing=`(self: PropTestNode; value: float) {.gdsync, name: "set_float_with_export_exp_easing".} =
   self.float_with_export_exp_easing = value
 
-proc string_with_export_multiline(self: PropTestNode): string {.gdsync, name: "get_string_with_export_multiline".} =
-  self.string_with_export_multiline
-proc `string_with_export_multiline=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_multiline".} =
-  self.string_with_export_multiline = value
+`@export_exp_easing`"float_with_export_exp_easing",
+    float_with_export_exp_easing,
+    `float_with_export_exp_easing=`
+`@export_exp_easing`"float_with_export_exp_easing_attenuation",
+    float_with_export_exp_easing,
+    `float_with_export_exp_easing=`,
+    attenuation
+`@export_exp_easing`"float_with_export_exp_easing_positive_only",
+    float_with_export_exp_easing,
+    `float_with_export_exp_easing=`,
+    positive_only
 
-proc StringArray_with_export_multiline(self: PropTestNode): TypedArray[String] {.gdsync, name: "get_StringArray_with_export_multiline".} =
-  self.StringArray_with_export_multiline
-proc `StringArray_with_export_multiline=`(self: PropTestNode; value: TypedArray[String]) {.gdsync, name: "set_StringArray_with_export_multiline".} =
-  self.StringArray_with_export_multiline = value
-
-proc PackedStringArray_with_export_multiline(self: PropTestNode): PackedStringArray {.gdsync, name: "get_PackedStringArray_with_export_multiline".} =
-  self.PackedStringArray_with_export_multiline
-proc `PackedStringArray_with_export_multiline=`(self: PropTestNode; value: PackedStringArray) {.gdsync, name: "set_PackedStringArray_with_export_multiline".} =
-  self.PackedStringArray_with_export_multiline = value
-
-proc NodePath_with_export_node_path(self: PropTestNode): NodePath {.gdsync, name: "get_NodePath_with_export_node_path".} =
-  self.NodePath_with_export_node_path
-proc `NodePath_with_export_node_path=`(self: PropTestNode; value: NodePath) {.gdsync, name: "set_NodePath_with_export_node_path".} =
-  self.NodePath_with_export_node_path = value
-
-proc int_with_export_strict_range(self: PropTestNode): int {.gdsync, name: "get_int_with_export_strict_range".} =
-  self.int_with_export_strict_range
-proc `int_with_export_strict_range=`(self: PropTestNode; value: int) {.gdsync, name: "set_int_with_export_strict_range".} =
-  self.int_with_export_strict_range = value
-
-proc int_with_export_range(self: PropTestNode): int {.gdsync, name: "get_int_with_export_range".} =
-  self.int_with_export_range
-proc `int_with_export_range=`(self: PropTestNode; value: int) {.gdsync, name: "set_int_with_export_range".} =
-  self.int_with_export_range = value
-
-proc radians_with_export_range_as_degrees(self: PropTestNode): float {.gdsync, name: "get_radians_with_export_range_as_degrees".} =
-  self.radians_with_export_range_as_degrees
-proc `radians_with_export_range_as_degrees=`(self: PropTestNode; value: float) {.gdsync, name: "set_radians_with_export_range_as_degrees".} =
-  self.radians_with_export_range_as_degrees = value
-
-proc string_with_export_storage(self: PropTestNode): string {.gdsync, name: "get_string_with_export_storage".} =
-  self.string_with_export_storage
-proc `string_with_export_storage=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_storage".} =
-  self.string_with_export_storage = value
-
-`@export_category` PropTestNode, "Export Test"
-
-`@export` "string_with_export", string_with_export, `string_with_export=`
-`@export_placeholder` "string_with_export_placeholder", string_with_export_placeholder, `string_with_export_placeholder=`,
-  "placeholder here..."
-
-`@export_group` PropTestNode, "filesystem"
-
-`@export_subgroup` ProptestNode, "local"
-`@export_dir` "string_with_export_dir", string_with_export_dir, `string_with_export_dir=`
-`@export_file` "string_with_export_file", string_with_export_file, `string_with_export_file=`
-
-`@export_subgroup` ProptestNode, "global"
-`@export_global_dir` "string_with_export_global_dir", string_with_export_global_dir, `string_with_export_global_dir=`
-`@export_global_file` "string_with_export_global_file", string_with_export_global_file, `string_with_export_global_file=`
-
-`@export_group` PropTestNode, ""
-
-`@export` "color_with_export", color_with_export, `color_with_export=`
-`@export_color_no_alpha` "color_with_export_no_alpha", color_with_export_no_alpha, `color_with_export_no_alpha=`
-
-`@export_enum` "int_with_export_enum", int_with_export_enum, `int_with_export_enum=`,
-  "Alpha", "Beta:10", "Gamma"
-`@export_enum` "string_with_export_enum", string_with_export_enum, `string_with_export_enum=`,
-  "Alpha", "Beta", "Gamma"
-
-`@export_flags` "int_with_export_flags", int_with_export_flags, `int_with_export_flags=`,
-  "Alpha", "Beta", "Gamma"
-
-`@export_flags_2d_navigation` "int_with_export_flags_2d_navigation", int_with_export_flags_some_layers, `int_with_export_flags_some_layers=`
-`@export_flags_2d_physics` "int_with_export_flags_2d_physics", int_with_export_flags_some_layers, `int_with_export_flags_some_layers=`
-`@export_flags_2d_render` "int_with_export_flags_2d_render", int_with_export_flags_some_layers, `int_with_export_flags_some_layers=`
-`@export_flags_3d_navigation` "int_with_export_flags_3d_navigation", int_with_export_flags_some_layers, `int_with_export_flags_some_layers=`
-`@export_flags_3d_physics` "int_with_export_flags_3d_physics", int_with_export_flags_some_layers, `int_with_export_flags_some_layers=`
-`@export_flags_3d_render` "int_with_export_flags_3d_render", int_with_export_flags_some_layers, `int_with_export_flags_some_layers=`
-`@export_flags_avoidance` "int_with_export_flags_avoidance", int_with_export_flags_some_layers, `int_with_export_flags_some_layers=`
-
-`@export_exp_easing` "float_with_export_exp_easing", float_with_export_exp_easing, `float_with_export_exp_easing=`
-`@export_exp_easing` "float_with_export_exp_easing_attenuation", float_with_export_exp_easing, `float_with_export_exp_easing=`,
-  attenuation
-`@export_exp_easing` "float_with_export_exp_easing_positive_only", float_with_export_exp_easing, `float_with_export_exp_easing=`,
-  positive_only
-
-`@export_multiline` "string_with_export_multiline", string_with_export_multiline, `string_with_export_multiline=`
+`@export_multiline`"string_with_export_multiline",
+    proc (self: PropTestNode): string = self.string_with_export_multiline,
+    proc (self: PropTestNode; value: string) = self.string_with_export_multiline = value
 # Currently not works,
-`@export_multiline` "StringArray_with_export_multiline", StringArray_with_export_multiline, `StringArray_with_export_multiline=`
-`@export_multiline` "PackedStringArray_with_export_multiline", PackedStringArray_with_export_multiline, `PackedStringArray_with_export_multiline=`
+`@export_multiline`"StringArray_with_export_multiline",
+    proc (self: PropTestNode): TypedArray[String] = self.StringArray_with_export_multiline,
+    proc (self: PropTestNode; value: TypedArray[String]) = self.StringArray_with_export_multiline = value
+`@export_multiline`"PackedStringArray_with_export_multiline",
+    proc (self: PropTestNode): PackedStringArray = self.PackedStringArray_with_export_multiline,
+    proc (self: PropTestNode; value: PackedStringArray) = self.PackedStringArray_with_export_multiline = value
 
-`@export_node_path` "NodePath_with_export_node_path", NodePath_with_export_node_path, `NodePath_with_export_node_path=`,
-  "Sprite2D"
-`@export_node_path` "NodePath_with_export_node_path_typedesc", NodePath_with_export_node_path, `NodePath_with_export_node_path=`,
-  Sprite2D
+`@export_node_path`"NodePath_with_export_node_path",
+    proc (self: PropTestNode): NodePath = self.NodePath_with_export_node_path,
+    proc (self: PropTestNode; value: NodePath) = self.NodePath_with_export_node_path = value,
+    "Sprite2D"
+`@export_node_path`"NodePath_with_export_node_path_typedesc",
+    proc (self: PropTestNode): NodePath = self.NodePath_with_export_node_path,
+    proc (self: PropTestNode; value: NodePath) = self.NodePath_with_export_node_path = value,
+    Sprite2D
 
-`@export_range` "int_with_export_strict_range", int_with_export_strict_range, `int_with_export_strict_range=`,
-  10, 100
-`@export_range` "int_with_export_range", int_with_export_range, `int_with_export_range=`,
-  10, 100, 5, or_less, or_greater
-`@export_range` "radians_with_export_range_as_degrees", radians_with_export_range_as_degrees, `radians_with_export_range_as_degrees=`,
-  0, 360, radians_as_degrees
+`@export_range`"int_with_export_strict_range",
+    proc (self: PropTestNode): int = self.int_with_export_strict_range,
+    proc (self: PropTestNode; value: int) = self.int_with_export_strict_range = value,
+    10, 100
+`@export_range`"int_with_export_range",
+    proc (self: PropTestNode): int = self.int_with_export_range,
+    proc (self: PropTestNode; value: int) = self.int_with_export_range = value,
+    10, 100, 5, or_less, or_greater
 
-`@export_storage` "string_with_export_storage", string_with_export_storage, `string_with_export_storage=`
+`@export_range`"radians_with_export_range_as_degrees",
+    proc (self: PropTestNode): float = self.radians_with_export_range_as_degrees,
+    proc (self: PropTestNode; value: float) = self.radians_with_export_range_as_degrees = value,
+    0, 360, radians_as_degrees
 
+`@export_storage`"string_with_export_storage",
+    proc (self: PropTestNode): string = self.string_with_export_storage,
+    proc (self: PropTestNode; value: string) = self.string_with_export_storage = value

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -2,12 +2,22 @@ import gdext
 
 type PropTestNode* = ref object of Node
   string_with_export*: string = "with export"
+  string_with_export_multiline*: string = """
+MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
+MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
+MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
+MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT"""
   string_with_export_storage*: string = "with export_storage"
 
 proc string_with_export(self: PropTestNode): string {.gdsync, name: "get_string_with_export".} =
   self.string_with_export
 proc `string_with_export=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export".} =
   self.string_with_export = value
+
+proc string_with_export_multiline(self: PropTestNode): string {.gdsync, name: "get_string_with_export_multiline".} =
+  self.string_with_export_multiline
+proc `string_with_export_multiline=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_multiline".} =
+  self.string_with_export_multiline = value
 
 proc string_with_export_storage(self: PropTestNode): string {.gdsync, name: "get_string_with_export_storage".} =
   self.string_with_export_storage
@@ -16,5 +26,6 @@ proc `string_with_export_storage=`(self: PropTestNode; value: string) {.gdsync, 
 
 `@export_category` "Export Test"
 `@export` "string_with_export", string_with_export, `string_with_export=`
+`@export_multiline` "string_with_export_multiline", string_with_export_multiline, `string_with_export_multiline=`
 `@export_storage` "string_with_export_storage", string_with_export_storage, `string_with_export_storage=`
 

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -16,6 +16,7 @@ MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
 MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT"""
   StringArray_with_export_multiline*: TypedArray[String]
   PackedStringArray_with_export_multiline*: PackedStringArray
+  NodePath_with_export_node_path*: NodePath
   string_with_export_storage*: string = "with export_storage"
   int_with_export_strict_range*: int = 20
   int_with_export_range*: int = 20
@@ -88,6 +89,11 @@ proc PackedStringArray_with_export_multiline(self: PropTestNode): PackedStringAr
 proc `PackedStringArray_with_export_multiline=`(self: PropTestNode; value: PackedStringArray) {.gdsync, name: "set_PackedStringArray_with_export_multiline".} =
   self.PackedStringArray_with_export_multiline = value
 
+proc NodePath_with_export_node_path(self: PropTestNode): NodePath {.gdsync, name: "get_NodePath_with_export_node_path".} =
+  self.NodePath_with_export_node_path
+proc `NodePath_with_export_node_path=`(self: PropTestNode; value: NodePath) {.gdsync, name: "set_NodePath_with_export_node_path".} =
+  self.NodePath_with_export_node_path = value
+
 proc int_with_export_strict_range(self: PropTestNode): int {.gdsync, name: "get_int_with_export_strict_range".} =
   self.int_with_export_strict_range
 proc `int_with_export_strict_range=`(self: PropTestNode; value: int) {.gdsync, name: "set_int_with_export_strict_range".} =
@@ -142,6 +148,11 @@ proc `string_with_export_storage=`(self: PropTestNode; value: string) {.gdsync, 
 # Currently not works,
 `@export_multiline` "StringArray_with_export_multiline", StringArray_with_export_multiline, `StringArray_with_export_multiline=`
 `@export_multiline` "PackedStringArray_with_export_multiline", PackedStringArray_with_export_multiline, `PackedStringArray_with_export_multiline=`
+
+`@export_node_path` "NodePath_with_export_node_path", NodePath_with_export_node_path, `NodePath_with_export_node_path=`,
+  "Sprite2D"
+`@export_node_path` "NodePath_with_export_node_path_typedesc", NodePath_with_export_node_path, `NodePath_with_export_node_path=`,
+  Sprite2D
 
 `@export_range` "int_with_export_strict_range", int_with_export_strict_range, `int_with_export_strict_range=`,
   10, 100

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -2,6 +2,7 @@ import gdext
 
 type PropTestNode* = ref object of Node
   string_with_export*: string = "with export"
+  string_with_export_placeholder*: string
   string_with_export_dir*: string = "res://nim"
   string_with_export_global_dir*: string = "/dev"
   string_with_export_file*: string = "res://nim/bootstrap.nim"
@@ -33,6 +34,11 @@ proc string_with_export(self: PropTestNode): string {.gdsync, name: "get_string_
   self.string_with_export
 proc `string_with_export=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export".} =
   self.string_with_export = value
+
+proc string_with_export_placeholder(self: PropTestNode): string {.gdsync, name: "get_string_with_export_placeholder".} =
+  self.string_with_export_placeholder
+proc `string_with_export_placeholder=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_placeholder".} =
+  self.string_with_export_placeholder = value
 
 proc string_with_export_dir(self: PropTestNode): string {.gdsync, name: "get_string_with_export_dir".} =
   self.string_with_export_dir
@@ -117,6 +123,8 @@ proc `string_with_export_storage=`(self: PropTestNode; value: string) {.gdsync, 
 `@export_category` PropTestNode, "Export Test"
 
 `@export` "string_with_export", string_with_export, `string_with_export=`
+`@export_placeholder` "string_with_export_placeholder", string_with_export_placeholder, `string_with_export_placeholder=`,
+  "placeholder here..."
 
 `@export_group` PropTestNode, "filesystem"
 

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -8,6 +8,7 @@ type PropTestNode* = ref object of Node
   string_with_export_global_file*: string = "/dev/null"
   int_with_export_enum*: int
   string_with_export_enum*: string = "Alpha"
+  float_with_export_exp_easing*: float = 2
   string_with_export_multiline*: string = """
 MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
 MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
@@ -67,6 +68,11 @@ proc string_with_export_enum(self: PropTestNode): string {.gdsync, name: "get_st
 proc `string_with_export_enum=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_enum".} =
   self.string_with_export_enum = value
 
+proc float_with_export_exp_easing(self: PropTestNode): float {.gdsync, name: "get_float_with_export_exp_easing".} =
+  self.float_with_export_exp_easing
+proc `float_with_export_exp_easing=`(self: PropTestNode; value: float) {.gdsync, name: "set_float_with_export_exp_easing".} =
+  self.float_with_export_exp_easing = value
+
 proc string_with_export_multiline(self: PropTestNode): string {.gdsync, name: "get_string_with_export_multiline".} =
   self.string_with_export_multiline
 proc `string_with_export_multiline=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_multiline".} =
@@ -125,6 +131,12 @@ proc `string_with_export_storage=`(self: PropTestNode; value: string) {.gdsync, 
   "Alpha", "Beta:10", "Gamma"
 `@export_enum` "string_with_export_enum", string_with_export_enum, `string_with_export_enum=`,
   "Alpha", "Beta", "Gamma"
+
+`@export_exp_easing` "float_with_export_exp_easing", float_with_export_exp_easing, `float_with_export_exp_easing=`
+`@export_exp_easing` "float_with_export_exp_easing_attenuation", float_with_export_exp_easing, `float_with_export_exp_easing=`,
+  attenuation
+`@export_exp_easing` "float_with_export_exp_easing_positive_only", float_with_export_exp_easing, `float_with_export_exp_easing=`,
+  positive_only
 
 `@export_multiline` "string_with_export_multiline", string_with_export_multiline, `string_with_export_multiline=`
 # Currently not works,

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -84,10 +84,17 @@ proc `string_with_export_storage=`(self: PropTestNode; value: string) {.gdsync, 
 
 `@export` "string_with_export", string_with_export, `string_with_export=`
 
+`@export_group` PropTestNode, "filesystem"
+
+`@export_sub_group` ProptestNode, "local"
 `@export_dir` "string_with_export_dir", string_with_export_dir, `string_with_export_dir=`
-`@export_global_dir` "string_with_export_global_dir", string_with_export_global_dir, `string_with_export_global_dir=`
 `@export_file` "string_with_export_file", string_with_export_file, `string_with_export_file=`
+
+`@export_sub_group` ProptestNode, "global"
+`@export_global_dir` "string_with_export_global_dir", string_with_export_global_dir, `string_with_export_global_dir=`
 `@export_global_file` "string_with_export_global_file", string_with_export_global_file, `string_with_export_global_file=`
+
+`@export_group` PropTestNode, ""
 
 `@export_multiline` "string_with_export_multiline", string_with_export_multiline, `string_with_export_multiline=`
 # Currently not works,

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -9,6 +9,7 @@ type PropTestNode* = ref object of Node
   string_with_export_global_file*: string = "/dev/null"
   int_with_export_enum*: int
   string_with_export_enum*: string = "Alpha"
+  int_with_export_flags*: int
   float_with_export_exp_easing*: float = 2
   string_with_export_multiline*: string = """
 MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
@@ -74,6 +75,11 @@ proc string_with_export_enum(self: PropTestNode): string {.gdsync, name: "get_st
   self.string_with_export_enum
 proc `string_with_export_enum=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_enum".} =
   self.string_with_export_enum = value
+
+proc int_with_export_flags(self: PropTestNode): int {.gdsync, name: "get_int_with_export_flags".} =
+  self.int_with_export_flags
+proc `int_with_export_flags=`(self: PropTestNode; value: int) {.gdsync, name: "set_int_with_export_flags".} =
+  self.int_with_export_flags = value
 
 proc float_with_export_exp_easing(self: PropTestNode): float {.gdsync, name: "get_float_with_export_exp_easing".} =
   self.float_with_export_exp_easing
@@ -144,6 +150,9 @@ proc `string_with_export_storage=`(self: PropTestNode; value: string) {.gdsync, 
 `@export_enum` "int_with_export_enum", int_with_export_enum, `int_with_export_enum=`,
   "Alpha", "Beta:10", "Gamma"
 `@export_enum` "string_with_export_enum", string_with_export_enum, `string_with_export_enum=`,
+  "Alpha", "Beta", "Gamma"
+
+`@export_flags` "int_with_export_flags", int_with_export_flags, `int_with_export_flags=`,
   "Alpha", "Beta", "Gamma"
 
 `@export_exp_easing` "float_with_export_exp_easing", float_with_export_exp_easing, `float_with_export_exp_easing=`

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -10,6 +10,7 @@ type PropTestNode* = ref object of Node
   int_with_export_enum*: int
   string_with_export_enum*: string = "Alpha"
   int_with_export_flags*: int
+  int_with_export_flags_some_layers*: int
   float_with_export_exp_easing*: float = 2
   string_with_export_multiline*: string = """
 MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
@@ -80,6 +81,11 @@ proc int_with_export_flags(self: PropTestNode): int {.gdsync, name: "get_int_wit
   self.int_with_export_flags
 proc `int_with_export_flags=`(self: PropTestNode; value: int) {.gdsync, name: "set_int_with_export_flags".} =
   self.int_with_export_flags = value
+
+proc int_with_export_flags_some_layers(self: PropTestNode): int {.gdsync, name: "get_int_with_export_flags_some_layers".} =
+  self.int_with_export_flags_some_layers
+proc `int_with_export_flags_some_layers=`(self: PropTestNode; value: int) {.gdsync, name: "set_int_with_export_flags_some_layers".} =
+  self.int_with_export_flags_some_layers = value
 
 proc float_with_export_exp_easing(self: PropTestNode): float {.gdsync, name: "get_float_with_export_exp_easing".} =
   self.float_with_export_exp_easing
@@ -154,6 +160,14 @@ proc `string_with_export_storage=`(self: PropTestNode; value: string) {.gdsync, 
 
 `@export_flags` "int_with_export_flags", int_with_export_flags, `int_with_export_flags=`,
   "Alpha", "Beta", "Gamma"
+
+`@export_flags_2d_navigation` "int_with_export_flags_2d_navigation", int_with_export_flags_some_layers, `int_with_export_flags_some_layers=`
+`@export_flags_2d_physics` "int_with_export_flags_2d_physics", int_with_export_flags_some_layers, `int_with_export_flags_some_layers=`
+`@export_flags_2d_render` "int_with_export_flags_2d_render", int_with_export_flags_some_layers, `int_with_export_flags_some_layers=`
+`@export_flags_3d_navigation` "int_with_export_flags_3d_navigation", int_with_export_flags_some_layers, `int_with_export_flags_some_layers=`
+`@export_flags_3d_physics` "int_with_export_flags_3d_physics", int_with_export_flags_some_layers, `int_with_export_flags_some_layers=`
+`@export_flags_3d_render` "int_with_export_flags_3d_render", int_with_export_flags_some_layers, `int_with_export_flags_some_layers=`
+`@export_flags_avoidance` "int_with_export_flags_avoidance", int_with_export_flags_some_layers, `int_with_export_flags_some_layers=`
 
 `@export_exp_easing` "float_with_export_exp_easing", float_with_export_exp_easing, `float_with_export_exp_easing=`
 `@export_exp_easing` "float_with_export_exp_easing_attenuation", float_with_export_exp_easing, `float_with_export_exp_easing=`,

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -17,6 +17,8 @@ MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT"""
   int_with_export_strict_range*: int = 20
   int_with_export_range*: int = 20
   radians_with_export_range_as_degrees*: float = PI/4
+  color_with_export*: Color = color(1, 1, 1, 0.5)
+  color_with_export_no_alpha*: Color = color(1, 1, 1)
 
 method init(self: PropTestNode) =
   self.StringArray_with_export_multiline = typedArray[String](1)
@@ -44,6 +46,15 @@ proc string_with_export_global_file(self: PropTestNode): string {.gdsync, name: 
   self.string_with_export_global_file
 proc `string_with_export_global_file=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_global_file".} =
   self.string_with_export_global_file = value
+
+proc color_with_export(self: PropTestNode): Color {.gdsync, name: "get_color_with_export".} =
+  self.color_with_export
+proc `color_with_export=`(self: PropTestNode; value: Color) {.gdsync, name: "set_color_with_export".} =
+  self.color_with_export= value
+proc color_with_export_no_alpha(self: PropTestNode): Color {.gdsync, name: "get_color_with_export_no_alpha".} =
+  self.color_with_export_no_alpha
+proc `color_with_export_no_alpha=`(self: PropTestNode; value: Color) {.gdsync, name: "set_color_with_export_no_alpha".} =
+  self.color_with_export_no_alpha= value
 
 proc string_with_export_multiline(self: PropTestNode): string {.gdsync, name: "get_string_with_export_multiline".} =
   self.string_with_export_multiline
@@ -95,6 +106,9 @@ proc `string_with_export_storage=`(self: PropTestNode; value: string) {.gdsync, 
 `@export_global_file` "string_with_export_global_file", string_with_export_global_file, `string_with_export_global_file=`
 
 `@export_group` PropTestNode, ""
+
+`@export` "color_with_export", color_with_export, `color_with_export=`
+`@export_color_no_alpha` "color_with_export_no_alpha", color_with_export_no_alpha, `color_with_export_no_alpha=`
 
 `@export_multiline` "string_with_export_multiline", string_with_export_multiline, `string_with_export_multiline=`
 # Currently not works,

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -6,6 +6,8 @@ type PropTestNode* = ref object of Node
   string_with_export_global_dir*: string = "/dev"
   string_with_export_file*: string = "res://nim/bootstrap.nim"
   string_with_export_global_file*: string = "/dev/null"
+  int_with_export_enum*: int
+  string_with_export_enum*: string = "Alpha"
   string_with_export_multiline*: string = """
 MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
 MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
@@ -55,6 +57,15 @@ proc color_with_export_no_alpha(self: PropTestNode): Color {.gdsync, name: "get_
   self.color_with_export_no_alpha
 proc `color_with_export_no_alpha=`(self: PropTestNode; value: Color) {.gdsync, name: "set_color_with_export_no_alpha".} =
   self.color_with_export_no_alpha= value
+
+proc int_with_export_enum(self: PropTestNode): int {.gdsync, name: "get_int_with_export_enum".} =
+  self.int_with_export_enum
+proc `int_with_export_enum=`(self: PropTestNode; value: int) {.gdsync, name: "set_int_with_export_enum".} =
+  self.int_with_export_enum = value
+proc string_with_export_enum(self: PropTestNode): string {.gdsync, name: "get_string_with_export_enum".} =
+  self.string_with_export_enum
+proc `string_with_export_enum=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_enum".} =
+  self.string_with_export_enum = value
 
 proc string_with_export_multiline(self: PropTestNode): string {.gdsync, name: "get_string_with_export_multiline".} =
   self.string_with_export_multiline
@@ -109,6 +120,11 @@ proc `string_with_export_storage=`(self: PropTestNode; value: string) {.gdsync, 
 
 `@export` "color_with_export", color_with_export, `color_with_export=`
 `@export_color_no_alpha` "color_with_export_no_alpha", color_with_export_no_alpha, `color_with_export_no_alpha=`
+
+`@export_enum` "int_with_export_enum", int_with_export_enum, `int_with_export_enum=`,
+  "Alpha", "Beta:10", "Gamma"
+`@export_enum` "string_with_export_enum", string_with_export_enum, `string_with_export_enum=`,
+  "Alpha", "Beta", "Gamma"
 
 `@export_multiline` "string_with_export_multiline", string_with_export_multiline, `string_with_export_multiline=`
 # Currently not works,

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -10,6 +10,9 @@ MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT"""
   StringArray_with_export_multiline*: TypedArray[String]
   PackedStringArray_with_export_multiline*: PackedStringArray
   string_with_export_storage*: string = "with export_storage"
+  int_with_export_strict_range*: int = 20
+  int_with_export_range*: int = 20
+  radians_with_export_range_as_degrees*: float = PI/4
 
 method init(self: PropTestNode) =
   self.StringArray_with_export_multiline = typedArray[String](1)
@@ -36,17 +39,41 @@ proc PackedStringArray_with_export_multiline(self: PropTestNode): PackedStringAr
 proc `PackedStringArray_with_export_multiline=`(self: PropTestNode; value: PackedStringArray) {.gdsync, name: "set_PackedStringArray_with_export_multiline".} =
   self.PackedStringArray_with_export_multiline = value
 
+proc int_with_export_strict_range(self: PropTestNode): int {.gdsync, name: "get_int_with_export_strict_range".} =
+  self.int_with_export_strict_range
+proc `int_with_export_strict_range=`(self: PropTestNode; value: int) {.gdsync, name: "set_int_with_export_strict_range".} =
+  self.int_with_export_strict_range = value
+
+proc int_with_export_range(self: PropTestNode): int {.gdsync, name: "get_int_with_export_range".} =
+  self.int_with_export_range
+proc `int_with_export_range=`(self: PropTestNode; value: int) {.gdsync, name: "set_int_with_export_range".} =
+  self.int_with_export_range = value
+
+proc radians_with_export_range_as_degrees(self: PropTestNode): float {.gdsync, name: "get_radians_with_export_range_as_degrees".} =
+  self.radians_with_export_range_as_degrees
+proc `radians_with_export_range_as_degrees=`(self: PropTestNode; value: float) {.gdsync, name: "set_radians_with_export_range_as_degrees".} =
+  self.radians_with_export_range_as_degrees = value
+
 proc string_with_export_storage(self: PropTestNode): string {.gdsync, name: "get_string_with_export_storage".} =
   self.string_with_export_storage
 proc `string_with_export_storage=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_storage".} =
   self.string_with_export_storage = value
 
 `@export_category` "Export Test"
+
 `@export` "string_with_export", string_with_export, `string_with_export=`
+
 `@export_multiline` "string_with_export_multiline", string_with_export_multiline, `string_with_export_multiline=`
 # Currently not works,
 `@export_multiline` "StringArray_with_export_multiline", StringArray_with_export_multiline, `StringArray_with_export_multiline=`
 `@export_multiline` "PackedStringArray_with_export_multiline", PackedStringArray_with_export_multiline, `PackedStringArray_with_export_multiline=`
+
+`@export_range` "int_with_export_strict_range", int_with_export_strict_range, `int_with_export_strict_range=`,
+  10, 100
+`@export_range` "int_with_export_range", int_with_export_range, `int_with_export_range=`,
+  10, 100, 5, or_less, or_greater
+`@export_range` "radians_with_export_range_as_degrees", radians_with_export_range_as_degrees, `radians_with_export_range_as_degrees=`,
+  0, 360, radians_as_degrees
 
 `@export_storage` "string_with_export_storage", string_with_export_storage, `string_with_export_storage=`
 

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -1,0 +1,12 @@
+import gdext
+
+type PropTestNode* = ref object of Node
+  string_with_export*: string
+
+proc string_with_export(self: PropTestNode): string {.gdsync, name: "get_string_with_export".} =
+  self.string_with_export
+proc `string_with_export=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export".} =
+  self.string_with_export = value
+
+`@export` "string_with_export", string_with_export, `string_with_export=`
+

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -12,8 +12,7 @@ MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT"""
   string_with_export_storage*: string = "with export_storage"
 
 method init(self: PropTestNode) =
-  self.StringArray_with_export_multiline = TypedArray[String] gdarray()
-  echo self.StringArray_with_export_multiline.Array.resize(1)
+  self.StringArray_with_export_multiline = typedArray[String](1)
   self.PackedStringArray_with_export_multiline = packedStringArray()
   echo self.PackedStringArray_with_export_multiline.resize(1)
 

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -7,7 +7,15 @@ MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
 MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
 MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
 MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT"""
+  StringArray_with_export_multiline*: TypedArray[String]
+  PackedStringArray_with_export_multiline*: PackedStringArray
   string_with_export_storage*: string = "with export_storage"
+
+method init(self: PropTestNode) =
+  self.StringArray_with_export_multiline = TypedArray[String] gdarray()
+  echo self.StringArray_with_export_multiline.Array.resize(1)
+  self.PackedStringArray_with_export_multiline = packedStringArray()
+  echo self.PackedStringArray_with_export_multiline.resize(1)
 
 proc string_with_export(self: PropTestNode): string {.gdsync, name: "get_string_with_export".} =
   self.string_with_export
@@ -19,6 +27,16 @@ proc string_with_export_multiline(self: PropTestNode): string {.gdsync, name: "g
 proc `string_with_export_multiline=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_multiline".} =
   self.string_with_export_multiline = value
 
+proc StringArray_with_export_multiline(self: PropTestNode): TypedArray[String] {.gdsync, name: "get_StringArray_with_export_multiline".} =
+  self.StringArray_with_export_multiline
+proc `StringArray_with_export_multiline=`(self: PropTestNode; value: TypedArray[String]) {.gdsync, name: "set_StringArray_with_export_multiline".} =
+  self.StringArray_with_export_multiline = value
+
+proc PackedStringArray_with_export_multiline(self: PropTestNode): PackedStringArray {.gdsync, name: "get_PackedStringArray_with_export_multiline".} =
+  self.PackedStringArray_with_export_multiline
+proc `PackedStringArray_with_export_multiline=`(self: PropTestNode; value: PackedStringArray) {.gdsync, name: "set_PackedStringArray_with_export_multiline".} =
+  self.PackedStringArray_with_export_multiline = value
+
 proc string_with_export_storage(self: PropTestNode): string {.gdsync, name: "get_string_with_export_storage".} =
   self.string_with_export_storage
 proc `string_with_export_storage=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_storage".} =
@@ -27,5 +45,9 @@ proc `string_with_export_storage=`(self: PropTestNode; value: string) {.gdsync, 
 `@export_category` "Export Test"
 `@export` "string_with_export", string_with_export, `string_with_export=`
 `@export_multiline` "string_with_export_multiline", string_with_export_multiline, `string_with_export_multiline=`
+# Currently not works,
+`@export_multiline` "StringArray_with_export_multiline", StringArray_with_export_multiline, `StringArray_with_export_multiline=`
+`@export_multiline` "PackedStringArray_with_export_multiline", PackedStringArray_with_export_multiline, `PackedStringArray_with_export_multiline=`
+
 `@export_storage` "string_with_export_storage", string_with_export_storage, `string_with_export_storage=`
 

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -8,5 +8,6 @@ proc string_with_export(self: PropTestNode): string {.gdsync, name: "get_string_
 proc `string_with_export=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export".} =
   self.string_with_export = value
 
+`@export_category` "Export Test"
 `@export` "string_with_export", string_with_export, `string_with_export=`
 

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -2,6 +2,10 @@ import gdext
 
 type PropTestNode* = ref object of Node
   string_with_export*: string = "with export"
+  string_with_export_dir*: string = "res://nim"
+  string_with_export_global_dir*: string = "/dev"
+  string_with_export_file*: string = "res://nim/bootstrap.nim"
+  string_with_export_global_file*: string = "/dev/null"
   string_with_export_multiline*: string = """
 MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
 MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
@@ -23,6 +27,23 @@ proc string_with_export(self: PropTestNode): string {.gdsync, name: "get_string_
   self.string_with_export
 proc `string_with_export=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export".} =
   self.string_with_export = value
+
+proc string_with_export_dir(self: PropTestNode): string {.gdsync, name: "get_string_with_export_dir".} =
+  self.string_with_export_dir
+proc `string_with_export_dir=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_dir".} =
+  self.string_with_export_dir = value
+proc string_with_export_global_dir(self: PropTestNode): string {.gdsync, name: "get_string_with_export_global_dir".} =
+  self.string_with_export_global_dir
+proc `string_with_export_global_dir=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_global_dir".} =
+  self.string_with_export_global_dir = value
+proc string_with_export_file(self: PropTestNode): string {.gdsync, name: "get_string_with_export_file".} =
+  self.string_with_export_file
+proc `string_with_export_file=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_file".} =
+  self.string_with_export_file = value
+proc string_with_export_global_file(self: PropTestNode): string {.gdsync, name: "get_string_with_export_global_file".} =
+  self.string_with_export_global_file
+proc `string_with_export_global_file=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_global_file".} =
+  self.string_with_export_global_file = value
 
 proc string_with_export_multiline(self: PropTestNode): string {.gdsync, name: "get_string_with_export_multiline".} =
   self.string_with_export_multiline
@@ -62,6 +83,11 @@ proc `string_with_export_storage=`(self: PropTestNode; value: string) {.gdsync, 
 `@export_category` "Export Test"
 
 `@export` "string_with_export", string_with_export, `string_with_export=`
+
+`@export_dir` "string_with_export_dir", string_with_export_dir, `string_with_export_dir=`
+`@export_global_dir` "string_with_export_global_dir", string_with_export_global_dir, `string_with_export_global_dir=`
+`@export_file` "string_with_export_file", string_with_export_file, `string_with_export_file=`
+`@export_global_file` "string_with_export_global_file", string_with_export_global_file, `string_with_export_global_file=`
 
 `@export_multiline` "string_with_export_multiline", string_with_export_multiline, `string_with_export_multiline=`
 # Currently not works,

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -1,13 +1,20 @@
 import gdext
 
 type PropTestNode* = ref object of Node
-  string_with_export*: string
+  string_with_export*: string = "with export"
+  string_with_export_storage*: string = "with export_storage"
 
 proc string_with_export(self: PropTestNode): string {.gdsync, name: "get_string_with_export".} =
   self.string_with_export
 proc `string_with_export=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export".} =
   self.string_with_export = value
 
+proc string_with_export_storage(self: PropTestNode): string {.gdsync, name: "get_string_with_export_storage".} =
+  self.string_with_export_storage
+proc `string_with_export_storage=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_storage".} =
+  self.string_with_export_storage = value
+
 `@export_category` "Export Test"
 `@export` "string_with_export", string_with_export, `string_with_export=`
+`@export_storage` "string_with_export_storage", string_with_export_storage, `string_with_export_storage=`
 

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -80,7 +80,7 @@ proc string_with_export_storage(self: PropTestNode): string {.gdsync, name: "get
 proc `string_with_export_storage=`(self: PropTestNode; value: string) {.gdsync, name: "set_string_with_export_storage".} =
   self.string_with_export_storage = value
 
-`@export_category` "Export Test"
+`@export_category` PropTestNode, "Export Test"
 
 `@export` "string_with_export", string_with_export, `string_with_export=`
 

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -86,11 +86,11 @@ proc `string_with_export_storage=`(self: PropTestNode; value: string) {.gdsync, 
 
 `@export_group` PropTestNode, "filesystem"
 
-`@export_sub_group` ProptestNode, "local"
+`@export_subgroup` ProptestNode, "local"
 `@export_dir` "string_with_export_dir", string_with_export_dir, `string_with_export_dir=`
 `@export_file` "string_with_export_file", string_with_export_file, `string_with_export_file=`
 
-`@export_sub_group` ProptestNode, "global"
+`@export_subgroup` ProptestNode, "global"
 `@export_global_dir` "string_with_export_global_dir", string_with_export_global_dir, `string_with_export_global_dir=`
 `@export_global_file` "string_with_export_global_file", string_with_export_global_file, `string_with_export_global_file=`
 

--- a/test/nim/src/godotSideTester.nim
+++ b/test/nim/src/godotSideTester.nim
@@ -1,12 +1,9 @@
 import gdext
 
 type GodotSideTester* = ref object of Node
-  int_value {.getter: "get_int_value", setter: "set_int_value".} : int
-  # Optional:
-  # hint: propertyHintNone
-  # usage: {propertyUsageStorage, propertyUsageEditor}
-  float_value {.getter: "get_float_value", setter: "set_float_value".} : float
-  icon {.getter: "get_icon", setter: "set_icon".} : gdref Texture2D
+  int_value: int
+  float_value: float
+  icon: gdref Texture2D
 
 # To register as static method, you must place typedesc[UserClass] at first argument
 # and put `{.gdsync.}`.
@@ -35,4 +32,6 @@ proc `icon=`*(self: GodotSideTester; value: gdref Texture2D) {.gdsync, name: "se
 proc icon*(self: GodotSideTester): gdref Texture2D {.gdsync, name: "get_icon".} =
   self.icon
 
-
+`@export` "int_value", int_value, `int_value=`
+`@export` "float_value", get_float_value, set_float_value
+`@export` "icon", icon, `icon=`


### PR DESCRIPTION
- [x] `@export`
- [x] `@export_category`
- [x] `@export_color_no_alpha`
- [x] `@export_custom`
- [x] `@export_dir`
- [x] `@export_enum`
- [x] `@export_exp_easing`
- [x] `@export_file`
- [x] `@export_flags`
- [x] `@export_flags_2d_navigation`
- [x] `@export_flags_2d_physics`
- [x] `@export_flags_2d_render`
- [x] `@export_flags_3d_navigation`
- [x] `@export_flags_3d_physics`
- [x] `@export_flags_3d_render`
- [x] `@export_flags_avoidance`
- [x] `@export_global_dir`
- [x] `@export_global_file`
- [x] `@export_group`
- [x] `@export_multiline`
- [x] `@export_node_path`
- [x] `@export_placeholder`
- [x] `@export_range`
- [x] `@export_storage`
- [x] `@export_subgroup`
- [x] accept lambda function as getter/setter
- [ ] ~~inspector macro that declaratively maps an entire property to an inspector view~~