### PR TITLE
Fix issue #65 by using relative import paths.

### DIFF
--- a/src/gdext/gdextwiz.nim
+++ b/src/gdext/gdextwiz.nim
@@ -2,11 +2,11 @@ import std/os
 import std/strutils
 import std/parseopt
 
-import gdext/wizard/sdk/opttools
+import ./wizard/sdk/opttools
 
-import gdext/wizard/subcommands/library
-import gdext/wizard/subcommands/extension
-import gdext/wizard/subcommands/iteration
+import ./wizard/subcommands/library
+import ./wizard/subcommands/extension
+import ./wizard/subcommands/iteration
 
 
 let help = """

--- a/src/gdext/wizard/sdk/clitools/filesystem.nim
+++ b/src/gdext/wizard/sdk/clitools/filesystem.nim
@@ -1,4 +1,4 @@
-import gdext/wizard/sdk/cli
+import ../cli
 
 import std/[os, strutils, strformat, options]
 

--- a/src/gdext/wizard/subcommands/extension.nim
+++ b/src/gdext/wizard/subcommands/extension.nim
@@ -1,5 +1,5 @@
-import gdext/wizard/sdk/cli
-import gdext/wizard/sdk/clitools/filesystem
+import ../sdk/cli
+import ../sdk/clitools/filesystem
 
 import std/[os, parseopt, strutils]
 

--- a/src/gdext/wizard/subcommands/iteration.nim
+++ b/src/gdext/wizard/subcommands/iteration.nim
@@ -1,7 +1,7 @@
 import std/[os, parseopt, strutils]
 
-import gdext/wizard/sdk/cli
-import gdext/wizard/sdk/opttools
+import ../sdk/cli
+import ../sdk/opttools
 
 proc nim_c(args: seq[string]; path: string): 0..1 =
   execShellCmd("nim c " & args.join(" ") & " " & path)


### PR DESCRIPTION
If this worked for you previously, it was probably because Nim used your nimble installed `gdext` to find the files.

Fixes #65.