### PR TITLE
Enhance variant operations

### DIFF
--- a/src/gdext.nim
+++ b/src/gdext.nim
@@ -6,7 +6,7 @@ import gdext/utils/staticevents
 export staticevents.process
 
 import gdext/dirty/gdextensioninterface
-export InitializationLevel, VariantType, gdcall
+export InitializationLevel, VariantType, gdcall, CallError, CallErrorType
 
 import gdext/core/[ builtinindex, geometrics, gdrefs, gdtypedarray ]
 export              builtinindex, geometrics, gdrefs, gdtypedarray

--- a/src/gdext/core/varianttools.nim
+++ b/src/gdext/core/varianttools.nim
@@ -1,0 +1,34 @@
+import gdext/core/commandindex
+import gdext/core/builtinindex
+
+proc stringify*(v: Variant): String =
+  interface_Variant_stringify(addr v, addr result)
+
+proc iter_init*(self: Variant; r_iter: var Variant; r_valid: var bool): bool =
+  interface_Variant_iterInit(addr self, addr r_iter, addr r_valid)
+
+proc iter_next*(self: Variant; r_iter: var Variant; r_valid: var bool): bool =
+  interface_Variant_iterNext(addr self, addr r_iter, addr r_valid)
+
+proc iter_get*(self: Variant; r_iter: var Variant; r_valid: var bool): Variant =
+  interface_Variant_iterGet(addr self, addr r_iter, addr result, addr r_valid)
+
+proc get_named*(self: Variant; name: StringName; r_isValid: var bool): Variant =
+  interface_variant_get_named(addr self, addr name, addr result, addr r_isValid)
+proc set_named*(self: Variant; name: StringName; value: Variant; r_isValid: var bool) =
+  interface_variant_set_named(addr self, addr name, addr value, addr r_isValid)
+
+proc get_indexed*(self: Variant; index: int; r_isValid, r_outOfBound: var bool): Variant =
+  interface_variant_get_indexed(addr self, index, addr result, addr r_isValid, addr r_outOfBound)
+proc set_indexed*(self: Variant; index: int; value: Variant; r_isValid, r_outOfBound: var bool) =
+  interface_variant_set_indexed(addr self, index, addr value, addr r_isValid, addr r_outOfBound)
+
+proc set_keyed*(self: Variant; key: Variant; value: Variant; r_isValid: var bool) =
+  interface_variant_set_keyed(addr self, addr key, addr value, addr r_isValid)
+proc get_keyed*(self: Variant; key: Variant; r_isValid: var bool): Variant =
+  interface_variant_get_keyed(addr self, addr key, addr result, addr r_isValid)
+
+proc get*(self: Variant; key: Variant; r_isValid: var bool): Variant =
+  interface_variant_get(addr self, addr key, addr result, addr r_isValid)
+proc set*(self: Variant; key: Variant; value: Variant; r_isValid: var bool) =
+  interface_variant_set(addr self, addr key, addr value, addr r_isValid)

--- a/src/gdext/surface/conversions.nim
+++ b/src/gdext/surface/conversions.nim
@@ -3,6 +3,7 @@ import gdext/core/gdclass
 import gdext/core/gdtypedarray
 import gdextgen/builtinclasses/constructors
 import gdext/surface/classutils
+import gdext/surface/variantutils
 
 {.push, inline.}
 
@@ -12,6 +13,8 @@ converter convertToNodePath*(str: string): NodePath = nodePath gdstring str
 
 converter convertToArray*(arr: TypedArray): Array = Array arr
 
-converter toSingleton*[T: GodotClass](_: typedesc[T]): T = singleton(T)
+converter convertToSingleton*[T: GodotClass](_: typedesc[T]): T = singleton(T)
+
+converter convertToBool*(variant: Variant): bool = variant.booleanize
 
 {.pop.}

--- a/src/gdext/surface/variantutils.nim
+++ b/src/gdext/surface/variantutils.nim
@@ -1,125 +1,153 @@
+import gdext/buildconf
 import gdext/dirty/gdextensioninterface
 import gdext/core/commandindex
 import gdext/core/builtinindex
 import gdext/core/typeshift
+import gdext/core/varianttools
 
-import std/hashes
+import std/[hashes, strformat, sequtils]
 
-proc stringify*(v: Variant): String =
-  interface_Variant_stringify(addr v, addr result)
+type VariantTypeDefect* = object of CatchableError
+type VariantCallError* = object of CatchableError
+
 proc `$`*(v: Variant): string = $v.stringify
 
-proc `variantType`*(v: Variant): VariantType =
+proc variantType*(v: Variant): VariantType =
   interfaceVariantGetType(addr v)
 
-proc evaluate*(op: VariantOperator; a, b: VariantPtr; ret: var Variant): bool =
-  interface_Variant_evaluate(op, a, b, addr ret, addr result)
+const OpName: array[VariantOperator, string] = [
+  "==",
+  "!=",
+  "<",
+  "<=",
+  ">",
+  ">=",
+  "+",
+  "-",
+  "*",
+  "/",
+  "+",
+  "-",
+  "mod",
+  "power",
+  "shl",
+  "shr",
+  "and",
+  "or",
+  "xor",
+  "not",
+  "and",
+  "or",
+  "xor",
+  "not",
+  "contains",
+]
+const ErrorName: array[CallErrorType, string] = [
+  "ok",
+  "invalid method",
+  "invalid argument",
+  "too many argument",
+  "too few argument",
+  "instance is nil",
+  "method not const",
+]
+
+template newVariantTypeDefect(op: VariantOperator; a, b: ptr Variant): ref VariantTypeDefect =
+  newException(VariantTypeDefect,
+    if b.isNil:
+      &"{OpName[op]} {variantType a[]} is invalid operation; type mismatch"
+    else:
+      &"{variantType a[]} {OpName[op]} {variantType b[]} is invalid operation; type mismatch")
+proc evaluate*(op: VariantOperator; a, b: ptr Variant; valid: var bool): Variant =
+  interface_Variant_evaluate(op, cast[VariantPtr](a), cast[VariantPtr](b), addr result, addr valid)
+proc evaluate*(op: VariantOperator; a, b: ptr Variant): Variant =
+  var valid: bool
+  result = evaluate(op, a, b, valid)
+  if not valid: raise newVariantTypeDefect(op, a, b)
 
 
 proc `==`*(self, other: Variant): bool =
-  if self.variantType != other.variantType: return
-  var res: Variant
-  if evaluate(VariantOP_Equal, addr self, addr other, res):
-    return res.get bool
+  var valid: bool
+  let res = evaluate(VariantOP_Equal, addr self, addr other, valid)
+  if not valid: self.variantType == other.variantType
+  else: res.get bool
+proc `!=`*(self, other: Variant): bool =
+  var valid: bool
+  let res = evaluate(VariantOP_NotEqual, addr self, addr other, valid)
+  if not valid: self.variantType != other.variantType
+  else: res.get bool
 
 proc `<`*(self, other: Variant): bool =
-  if self.variantType != other.variantType:
-    return self.variantType < other.variantType
-  var res: Variant
-  if evaluate(VariantOP_Less, addr self, addr other, res):
-    return res.get bool
+  evaluate(VariantOP_Less, addr self, addr other).get bool
+proc `<=`*(self, other: Variant): bool =
+  evaluate(VariantOP_LessEqual, addr self, addr other).get bool
+proc `>`*(self, other: Variant): bool =
+  evaluate(VariantOP_Greater, addr self, addr other).get bool
+proc `>=`*(self, other: Variant): bool =
+  evaluate(VariantOP_GreaterEqual, addr self, addr other).get bool
 
-proc call*(self: Variant; `method`: StringName; err: var CallError; args: varargs[VariantPtr]): Variant =
-  let head: ptr VariantPtr =
-    if args.len == 0: nil
-    else: addr args[0]
-  interface_Variant_call(addr self, addr `method`, head, args.len, addr result, addr err)
+proc contains*(self: Variant; index: Variant): bool =
+  evaluate(VariantOpIn, addr index, addr self).get bool
 
-proc callStatic*(_: typedesc[Variant]; T: VariantType; `method`: StringName; err: var CallError; args: varargs[VariantPtr]): Variant =
-  let head: ptr VariantPtr =
-    if args.len == 0: nil
-    else: addr args[0]
-  interface_Variant_callStatic(T, addr `method`, head, args.len, addr result, addr err)
+proc call*(self: Variant; `method`: StringName; err: var CallError; args: varargs[Variant, variant]): Variant {.discardable.} =
+  if args.len == 0:
+    interface_Variant_call(addr self, addr `method`, nil, 0, addr result, addr err)
+  else:
+    let args = args.mapIt(cast[pointer](addr it))
+    interface_Variant_call(addr self, addr `method`, addr args[0], args.len, addr result, addr err)
 
+proc callStatic*(T: VariantType; `method`: StringName; err: var CallError; args: varargs[Variant, variant]): Variant {.discardable.} =
+  if args.len == 0:
+    interface_Variant_callStatic(T, addr `method`, nil, 0, addr result, addr err)
+  else:
+    let args = args.mapIt(cast[pointer](addr it))
+    interface_Variant_callStatic(T, addr `method`, addr args[0], args.len, addr result, addr err)
+
+proc call*(self: Variant; `method`: StringName; args: varargs[Variant, variant]): Variant {.discardable.} =
+  var err: CallError
+  result = self.call(`method`, err, args)
+  if err.error != CallOk:
+    raise newException(VariantCallError, ErrorName[err.error])
+
+proc callStatic*(T: VariantType; `method`: StringName; args: varargs[Variant, variant]): Variant {.discardable.} =
+  var err: CallError
+  result = callStatic(T, `method`, err, args)
+  if err.error != CallOk:
+    raise newException(VariantCallError, ErrorName[err.error])
 
 template check_type(defect; mhd: string; v): untyped =
   if not isValid: raise newException(defect, mhd & " is invalid. Variant(" & $self.variantType & ") cannot contain Variant(" & $v.variantType & ").")
 template check_bound(defect): untyped =
   if outOfBound: raise newException(defect, "Out of bound. Got index " & $index & ".")
 
-proc set*(self: Variant; key: Variant; value: Variant; r_isValid: var bool) =
-  interface_variant_set(addr self, addr key, addr value, addr r_isValid)
 proc `[]=`*(self: Variant; key: Variant; value: Variant) =
   var isValid: bool
   self.set(key, value, isValid)
   check_type KeyError, "set[Variant]", value
   if not isValid: raise newException(IndexDefect, "")
-proc get*(self: Variant; key: Variant; r_isValid: var bool): Variant =
-  interface_variant_get(addr self, addr key, addr result, addr r_isValid)
-proc `[]`*(self: Variant; key: Variant): Variant =
-  var isValid: bool
-  result = self.get(key, isValid)
-  check_type KeyError, "get[Variant]", result
-
-proc set_named*(self: Variant; name: StringName; value: Variant; r_isValid: var bool) =
-  interface_variant_set_named(addr self, addr name, addr value, addr r_isValid)
 proc `[]=`*(self: Variant; name: StringName; value: Variant) =
   var isValid: bool
   self.set_named(name, value, isValid)
   check_type KeyError, "set[StringName]", value
-proc get_named*(self: Variant; name: StringName; r_isValid: var bool): Variant =
-  interface_variant_get_named(addr self, addr name, addr result, addr r_isValid)
-proc `[]`*(self: Variant; name: StringName): Variant =
-  var isValid: bool
-  result = self.get_named(name, isValid)
-  check_type KeyError, "get[StringName]", result
-
-proc set_indexed*(self: Variant; index: int; value: Variant; r_isValid, r_outOfBound: var bool) =
-  interface_variant_set_indexed(addr self, index, addr value, addr r_isValid, addr r_outOfBound)
 proc `[]=`*(self: Variant; index: int; value: Variant) =
   var isValid, outOfBound: bool
   self.set_indexed(index, value, isValid, outOfBound)
   check_type IndexDefect, "set[int]", value
   check_bound IndexDefect
-proc get_indexed*(self: Variant; index: int; r_isValid, r_outOfBound: var bool): Variant =
-  interface_variant_get_indexed(addr self, index, addr result, addr r_isValid, addr r_outOfBound)
+
+proc `[]`*(self: Variant; key: Variant): Variant =
+  var isValid: bool
+  result = self.get(key, isValid)
+  check_type KeyError, "get[Variant]", result
+proc `[]`*(self: Variant; name: StringName): Variant =
+  var isValid: bool
+  result = self.get_named(name, isValid)
+  check_type KeyError, "get[StringName]", result
 proc `[]`*(self: Variant; index: int): Variant =
   var isValid, outOfBound: bool
   result = self.get_indexed(index, isValid, outOfBound)
   check_type IndexDefect, "get[int]", result
   check_bound IndexDefect
-
-proc set_keyed*(self: Variant; key: Variant; value: Variant; r_isValid: var bool) =
-  interface_variant_set_keyed(addr self, addr key, addr value, addr r_isValid)
-# proc `[]=`*(self: Variant; key: Variant; value: Variant) =
-#   var isValid: bool
-#   self.set_keyed(key, value, isValid)
-#   check_type KeyError, "set[Variant]", value
-proc get_keyed*(self: Variant; key: Variant; r_isValid: var bool): Variant =
-  interface_variant_get_keyed(addr self, addr key, addr result, addr r_isValid)
-# proc `[]`*(self: Variant; key: Variant): Variant =
-#   var isValid: bool
-#   result = self.get_keyed(key, isValid)
-#   check_type KeyError, "get[Variant]", result
-
-# bool Variant::in(const Variant &index, bool *r_valid) const {
-#   Variant result;
-#   bool valid;
-#   evaluate(OP_IN, *this, index, result, valid);
-#   if (r_valid) {
-#     *r_valid = valid;
-#   }
-#   return result.operator bool();
-# }
-
-proc iter_init*(self: Variant; r_iter: var Variant; r_valid: var bool): bool =
-  interface_Variant_iterInit(addr self, addr r_iter, addr r_valid)
-
-proc iter_next*(self: Variant; r_iter: var Variant; r_valid: var bool): bool =
-  interface_Variant_iterNext(addr self, addr r_iter, addr r_valid)
-
-proc iter_get*(self: Variant; r_iter: var Variant; r_valid: var bool): Variant =
-  interface_Variant_iterGet(addr self, addr r_iter, addr result, addr r_valid)
 
 iterator keys*(self: Variant): Variant =
   var iter: Variant
@@ -134,112 +162,80 @@ iterator items*(self: Variant): Variant =
 iterator pairs*(self: Variant): tuple[key, item: Variant] =
   for key in self.keys: yield (key, self[key])
 
-proc has_key*(self: Variant; key: Variant; r_valid: ptr bool = nil): bool =
-  var valid: bool
-  result = interface_Variant_hasKey(addr self, addr key, addr valid)
-  if r_valid != nil: r_valid[] = valid
+proc hasMethod*(self: Variant; metho: StringName): bool =
+  interfaceVariantHasMethod(addr self, addr metho)
 
-# bool Variant::has_method(const StringName &method) const {
-#   GDExtensionBool has = internal::gdextension_interface_variant_has_method(_native_ptr(), method._native_ptr());
-#   return PtrToArg<bool>::convert(&has);
-# }
-
-# bool Variant::has_member(Variant::Type type, const StringName &member) {
-#   GDExtensionBool has = internal::gdextension_interface_variant_has_member(static_cast<GDExtensionVariantType>(type), member._native_ptr());
-#   return PtrToArg<bool>::convert(&has);
-# }
+proc hasMember*(typ: VariantType; member: StringName): bool =
+  interfaceVariantHasMember(typ, addr member)
 
 proc hash*(self: Variant): Hash = hash interface_Variant_hash(addr self)
 
-# uint32_t Variant::recursive_hash(int recursion_count) const {
-#   GDExtensionInt hash = internal::gdextension_interface_variant_recursive_hash(_native_ptr(), recursion_count);
-#   return PtrToArg<uint32_t>::convert(&hash);
-# }
+proc recursiveHash*(self: Variant; recursion_count: int): Hash =
+  hash interfaceVariantRecursiveHash(addr self, recursion_count)
 
-# bool Variant::hash_compare(const Variant &variant) const {
-#   GDExtensionBool compare = internal::gdextension_interface_variant_hash_compare(_native_ptr(), variant._native_ptr());
-#   return PtrToArg<bool>::convert(&compare);
-# }
+proc hashCompare*(self, other: Variant): bool =
+  interfaceVariantHashCompare(addr self, addr other)
 
-# bool Variant::booleanize() const {
-#   GDExtensionBool booleanized = internal::gdextension_interface_variant_booleanize(_native_ptr());
-#   return PtrToArg<bool>::convert(&booleanized);
-# }
+proc booleanize*(self: Variant): bool =
+  interfaceVariantBooleanize(addr self)
 
-# Variant Variant::duplicate(bool deep) const {
-#   Variant result;
-#   GDExtensionBool _deep;
-#   PtrToArg<bool>::encode(deep, &_deep);
-#   internal::gdextension_interface_variant_duplicate(_native_ptr(), result._native_ptr(), _deep);
-#   return result;
-# }
+proc duplicate*(self: Variant): Variant =
+  interfaceVariantDuplicate(addr self, addr result, true)
 
-# String Variant::get_type_name(Variant::Type type) {
-#   String result;
-#   internal::gdextension_interface_variant_get_type_name(static_cast<GDExtensionVariantType>(type), result._native_ptr());
-#   return result;
-# }
+proc canConvert*(src, dst: VariantType): bool =
+  interfaceVariantCanConvert(src, dst)
 
-# bool Variant::can_convert(Variant::Type from, Variant::Type to) {
-#   GDExtensionBool can = internal::gdextension_interface_variant_can_convert(static_cast<GDExtensionVariantType>(from), static_cast<GDExtensionVariantType>(to));
-#   return PtrToArg<bool>::convert(&can);
-# }
+proc canConvertStrict*(src, dst: VariantType): bool =
+  interfaceVariantCanConvertStrict(src, dst)
 
-# bool Variant::can_convert_strict(Variant::Type from, Variant::Type to) {
-#   GDExtensionBool can = internal::gdextension_interface_variant_can_convert_strict(static_cast<GDExtensionVariantType>(from), static_cast<GDExtensionVariantType>(to));
-#   return PtrToArg<bool>::convert(&can);
-# }
+proc clear*(self: Variant) =
+  const needs_deinit: array[VariantType, bool] = [
+    false, # NIL,
+    false, # BOOL,
+    false, # INT,
+    false, # FLOAT,
+    true, # STRING,
+    false, # VECTOR2,
+    false, # VECTOR2I,
+    false, # RECT2,
+    false, # RECT2I,
+    false, # VECTOR3,
+    false, # VECTOR3I,
+    true, # TRANSFORM2D,
+    false, # VECTOR4,
+    false, # VECTOR4I,
+    false, # PLANE,
+    false, # QUATERNION,
+    true, # AABB,
+    true, # BASIS,
+    true, # TRANSFORM3D,
+    true, # PROJECTION,
 
-# void Variant::clear() {
-#   static const bool needs_deinit[Variant::VARIANT_MAX] = {
-#     false, // NIL,
-#     false, // BOOL,
-#     false, // INT,
-#     false, // FLOAT,
-#     true, // STRING,
-#     false, // VECTOR2,
-#     false, // VECTOR2I,
-#     false, // RECT2,
-#     false, // RECT2I,
-#     false, // VECTOR3,
-#     false, // VECTOR3I,
-#     true, // TRANSFORM2D,
-#     false, // VECTOR4,
-#     false, // VECTOR4I,
-#     false, // PLANE,
-#     false, // QUATERNION,
-#     true, // AABB,
-#     true, // BASIS,
-#     true, // TRANSFORM3D,
-#     true, // PROJECTION,
+    # misc types
+    false, # COLOR,
+    true, # STRING_NAME,
+    true, # NODE_PATH,
+    false, # RID,
+    true, # OBJECT,
+    true, # CALLABLE,
+    true, # SIGNAL,
+    true, # DICTIONARY,
+    true, # ARRAY,
 
-#     // misc types
-#     false, // COLOR,
-#     true, // STRING_NAME,
-#     true, // NODE_PATH,
-#     false, // RID,
-#     true, // OBJECT,
-#     true, // CALLABLE,
-#     true, // SIGNAL,
-#     true, // DICTIONARY,
-#     true, // ARRAY,
+    # typed arrays
+    true, # PACKED_BYTE_ARRAY,
+    true, # PACKED_INT32_ARRAY,
+    true, # PACKED_INT64_ARRAY,
+    true, # PACKED_FLOAT32_ARRAY,
+    true, # PACKED_FLOAT64_ARRAY,
+    true, # PACKED_STRING_ARRAY,
+    true, # PACKED_VECTOR2_ARRAY,
+    true, # PACKED_VECTOR3_ARRAY,
+    true, # PACKED_COLOR_ARRAY,
+    when Extension.version >= (4, 3):
+      true, # PACKED_VECTOR4_ARRAY,
+  ]
 
-#     // typed arrays
-#     true, // PACKED_BYTE_ARRAY,
-#     true, // PACKED_INT32_ARRAY,
-#     true, // PACKED_INT64_ARRAY,
-#     true, // PACKED_FLOAT32_ARRAY,
-#     true, // PACKED_FLOAT64_ARRAY,
-#     true, // PACKED_STRING_ARRAY,
-#     true, // PACKED_VECTOR2_ARRAY,
-#     true, // PACKED_VECTOR3_ARRAY,
-#     true, // PACKED_COLOR_ARRAY,
-#   };
-
-#   if (unlikely(needs_deinit[get_type()])) { // Make it fast for types that don't need deinit.
-#     internal::gdextension_interface_variant_destroy(_native_ptr());
-#   }
-#   internal::gdextension_interface_variant_new_nil(_native_ptr());
-# }
-
-# } // namespace godot
+  if unlikely(needs_deinit[self.variantType]):
+    interfaceVariantDestroy(addr self)
+  interfaceVariantNewNil(addr self)

--- a/test/main.tscn
+++ b/test/main.tscn
@@ -15,5 +15,3 @@ script = ExtResource("1_x2b6x")
 texture = ExtResource("2_p8ptw")
 
 [node name="PropTestNode" type="PropTestNode" parent="."]
-
-[connection signal="custom_signal" from="TesterNIM" to="TesterGD" method="_on_tester_nim_custom_signal"]

--- a/test/nim/bootstrap.nim
+++ b/test/nim/bootstrap.nim
@@ -8,6 +8,7 @@ import godotSideTester
 import geometrics
 import cases/use_api_from_toplevel
 import cases/array
+import cases/variant
 import classes/gdNimSideTester
 import classes/gdproptestnode
 import classes/gdtestobject

--- a/test/nim/src/cases/array.nim
+++ b/test/nim/src/cases/array.nim
@@ -1,5 +1,6 @@
 import gdext
 import std/unittest
+unittest.disableParamFiltering()
 
 suite "TypedArray":
   test "construct":

--- a/test/nim/src/cases/use_api_from_toplevel.nim
+++ b/test/nim/src/cases/use_api_from_toplevel.nim
@@ -1,4 +1,5 @@
 import std/unittest
+unittest.disableParamFiltering()
 
 import gdext
 import gdext/core/gdclass

--- a/test/nim/src/cases/variant.nim
+++ b/test/nim/src/cases/variant.nim
@@ -1,0 +1,92 @@
+import gdext
+import std/unittest
+unittest.disableParamFiltering()
+
+suite "Variant":
+  test "has.*":
+    var vresource = variant instantiate Resource
+    var vstring = variant "hello, variant!"
+    check vstring.hasMethod("bin_to_int")
+    check vresource.hasMethod("reference")
+    check hasMember(VariantTypeColor, "r")
+
+  test "call error":
+    var err: CallError
+    var vdict = variant dictionary()
+    check vdict.call("size").get(int) == 0
+    expect VariantCallError: discard vdict.call("nonexistence")
+    expect VariantCallError: discard vdict.call("size", "Extra Argument")
+    discard vdict.call("nonexistence", err)
+    check err.error == CallError_InvalidMethod
+    discard vdict.call("size", err, "Extra Argument")
+    check err.error == CallError_TooManyArguments
+
+  test "equalability":
+    var v1i = variant 1
+    var v1idash = variant 1
+    var v2i = variant 2
+    var v1f = variant 1d
+    var vstring = variant "hello, variant!"
+    check v1i == v1i
+    check v1i == v1idash
+    check v1i == v1f
+    check v1i != v2i
+    check v1i != vstring
+    check v1i < v2i
+    check v1i <= v1i
+    check v1i <= v2i
+    check v2i > v1i
+    check v1i >= v1i
+    check v2i >= v1i
+
+  test "booleanize":
+    check not variant()
+    check variant 1
+    check not variant 0
+    check variant "String"
+    check not variant ""
+    check not variant gdarray()
+
+  test "Dictionary in Variant":
+    var vdict = variant dictionary()
+    check vdict.call("size").get(int) == 0
+    vdict[variant"Key1"] = variant 1
+    check vdict.call("size").get(int) == 1
+    check vdict["Key1"].get(int) == 1
+    vdict[variant"Key2"] = variant 2
+    check variant"Key2" in vdict
+
+    for key, val in vdict.pairs:
+      case key.variantType
+      of VariantTypeString:
+        case key.get(string)
+        of "Key1":
+          check val.get(int) == 1
+        of "Key2":
+          check val.get(int) == 2
+        else: check false
+      else: check false
+
+
+  test "Array in Variant":
+    var varr = variant gdarray()
+    check varr.call("size").get(int) == 0
+    varr.call("append", "Value1")
+    check varr.call("size").get(int) == 1
+    check varr[0] == variant "Value1"
+    varr.call("resize", 2)
+    check varr.call("size").get(int) == 2
+    check varr[1] == variant()
+    varr[1] = variant "Value2"
+    check variant"Value2" in varr
+
+    var i: int
+    for key, val in varr.pairs:
+      check key.get(int) == i
+      check val.get(string) == "Value" & $i.succ
+      inc i
+
+    var deep = duplicate varr
+    check deep[1].get(string) == "Value2"
+    varr[1] = variant "Value3"
+    check deep[1].get(string) == "Value2"

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -30,7 +30,7 @@ MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT"""
 method init(self: PropTestNode) =
   self.StringArray_with_export_multiline = typedArray[String](1)
   self.PackedStringArray_with_export_multiline = packedStringArray()
-  echo self.PackedStringArray_with_export_multiline.resize(1)
+  assert self.PackedStringArray_with_export_multiline.resize(1) == 0
 
 `@export_category`PropTestNode, "Export Test"
 

--- a/test/tester.gd
+++ b/test/tester.gd
@@ -60,9 +60,6 @@ func test_grobal_func():
 func _process(delta):
 	pass
 
-func _on_tester_nim_custom_signal(value):
-	assert(value == 10)
-
 func _on_nim_signal_arg0():
 	signal_arg0_executed = true
 func _on_nim_signal_arg1(what):


### PR DESCRIPTION
Referring to godot-cpp, add a set of API functions to make it easier to handle variants from Nim.

Functions Added:
```nim
proc evaluate*(op: VariantOperator; a, b: ptr Variant; valid: var bool): Variant
proc evaluate*(op: VariantOperator; a, b: ptr Variant): Variant
proc `==`*(self, other: Variant): bool
proc `!=`*(self, other: Variant): bool
proc `<`*(self, other: Variant): bool
proc `<=`*(self, other: Variant): bool
proc `>`*(self, other: Variant): bool
proc `>=`*(self, other: Variant): bool
proc contains*(self: Variant; index: Variant): bool
proc call*(self: Variant; `method`: StringName; err: var CallError; args: varargs[Variant, variant]): Variant {.discardable.}
proc call*(self: Variant; `method`: StringName; args: varargs[Variant, variant]): Variant {.discardable.}
proc callStatic*(T: VariantType; `method`: StringName; err: var CallError; args: varargs[Variant, variant]): Variant {.discardable.}
proc callStatic*(T: VariantType; `method`: StringName; args: varargs[Variant, variant]): Variant {.discardable.}
proc hasMethod*(self: Variant; metho: StringName): bool
proc hasMember*(typ: VariantType; member: StringName): bool
proc recursiveHash*(self: Variant; recursion_count: int): Hash
proc hashCompare*(self, other: Variant): bool
proc booleanize*(self: Variant): bool
proc duplicate*(self: Variant): Variant
proc canConvert*(src, dst: VariantType): bool
proc canConvertStrict*(src, dst: VariantType): bool
proc clear*(self: Variant)
```