### PR TITLE
Change all classes from ref-based to ptr-based

### DIFF
--- a/src/gdext/core/gdclass.nim
+++ b/src/gdext/core/gdclass.nim
@@ -1,4 +1,4 @@
-import std/[tables]
+import std/[tables, typetraits]
 
 import gdext/buildconf
 
@@ -25,23 +25,13 @@ when Dev.debugCallbacks:
     DESTROY          = "SYNC------------DESTROY: "
 
 type
-  ObjectControlFlag* = enum
-    OC_godotManaged
-
   ObjectControl* = object
     owner*: ObjectPtr
-    flags*: set[ObjectControlFlag]
     when Dev.debugCallbacks:
       name*: string
 
-proc `=destroy`*(x: ObjectControl) =
-  when Dev.debugCallbacks:
-    echo SYNC.DESTROY, x.name
-  if OC_godotManaged notin x.flags:
-    interfaceObjectDestroy(x.owner)
-
 type
-  GodotClass* = ref object of RootObj
+  GodotClass* = ptr object of RootObj
     control: ObjectControl
   GodotClassMeta* = object
     virtualMethods*: Table[StringName, ClassCallVirtual]
@@ -65,34 +55,29 @@ proc CLASS_getObjectPtrPtr*(class: GodotClass): ptr ObjectPtr =
   if unlikely(class.isNil or class.control.owner.isNil): nil
   else: addr class.control.owner
 
-proc CLASS_passOwnershipToGodot*(class: GodotClass) =
-  class.control.flags.incl OC_godotManaged
-  GC_ref class
-proc CLASS_unlockDestroy*(class: GodotClass) =
-  if OC_godotManaged in class.control.flags:
-    GC_unref class
+method onInit*(self: GodotClass) {.base.} = discard
+method onDestroy*(self: GodotClass) {.base.} = discard
 
-method init*(self: GodotClass) {.base.} = discard
-
-proc createClass*[T: SomeClass](Type: typedesc[T]; o: ObjectPtr): Type =
-  result = Type(
+proc createClass*[T: SomeClass](o: ObjectPtr): T =
+  result = cast[T](alloc sizeof pointerBase T)
+  zeroMem result, sizeof pointerBase T
+  result[] = (pointerBase T)(
     control: ObjectControl(
       owner: o, ))
   when Dev.debugCallbacks:
-    result.control.name = $Type
-  init result
+    result.control.name = $T
+  onInit result
 
 
 proc create_callback[T](p_token: pointer; p_instance: pointer): pointer {.gdcall.} =
-  let class = createClass(T, cast[ObjectPtr](p_instance))
-  CLASS_passOwnershipToGodot class
+  let class = createClass[T](cast[ObjectPtr](p_instance))
   result = cast[pointer](class)
   when Dev.debugCallbacks:
     echo SYNC.CREATE_CALL, class.control.name
 
 proc free_callback(p_token: pointer; p_instance: pointer; p_binding: pointer) {.gdcall.} =
   let class = cast[GodotClass](p_binding)
-  CLASS_unlockDestroy class
+  onDestroy class
   when Dev.debugCallbacks:
     echo SYNC.FREE_CALL, class.control.name
 

--- a/src/gdext/gdextensionmain.nim
+++ b/src/gdext/gdextensionmain.nim
@@ -9,7 +9,7 @@ import std/macros
 macro defExtensionMain: untyped =
   let typ = ident Extension.name
   quote do:
-    type `typ`* = ref object of Object
+    type `typ`* = ptr object of Object
 
 defExtensionMain
 
@@ -17,7 +17,7 @@ macro ExtensionMain*: untyped = bindSym Extension.name
 
 var extmain*: ExtensionMain
 
-method init(self: ExtensionMain) =
+method onInit(self: ExtensionMain) =
   discard
 
 template initializeExtensionMain* =
@@ -26,7 +26,7 @@ template initializeExtensionMain* =
   Engine.singleton.registerSingleton(className ExtensionMain, extmain)
 template eliminateExtensionMain* =
   Engine.singleton.unregisterSingleton(className ExtensionMain)
-  extmain = nil
+  destroy extmain
 
 when isMainModule:
   import gdext/dirty/gdextensioninterface

--- a/src/gdext/surface/userclass.nim
+++ b/src/gdext/surface/userclass.nim
@@ -49,7 +49,6 @@ proc to_string_func(p_instance: ClassInstancePtr; r_is_valid: ptr Bool; p_out: S
 
 proc create_instance_func[T: SomeUserClass](p_userdata: pointer): ObjectPtr {.gdcall.} =
   let class = instantiate_internal T
-  CLASS_passOwnershipToGodot class
   result =  CLASS_getObjectPtr class
   when Dev.debugCallbacks:
     privateAccess GodotClass
@@ -57,14 +56,13 @@ proc create_instance_func[T: SomeUserClass](p_userdata: pointer): ObjectPtr {.gd
 
 proc free_instance_func(p_userdata: pointer; p_instance: pointer) {.gdcall.} =
   let class = cast[GodotClass](p_instance)
-  CLASS_unlockDestroy class
+  onDestroy class
   when Dev.debugCallbacks:
     echo SYNC.FREE_BIND, class.control.name
 
 when Extension.version >= (4, 2):
   proc recreate_instance_func[T: SomeUserClass](p_class_userdata: pointer; p_object: ObjectPtr): ClassInstancePtr {.gdcall.} =
-    let class = createClass(T, p_object)
-    CLASS_passOwnershipToGodot class
+    let class = createClass[T](p_object)
     result = cast[pointer](class)
     when Dev.debugCallbacks:
       privateAccess GodotClass

--- a/test/nim/src/cases/use_api_from_toplevel.nim
+++ b/test/nim/src/cases/use_api_from_toplevel.nim
@@ -43,6 +43,9 @@ test "instantiate at global":
   check CLASS_getObjectPtr(engineclass) != nil
   check CLASS_getObjectPtr(extentclass) != nil
 
+  destroy engineclass
+  destroy extentclass
+
 test "connect to global signal":
   var signal_arg0_obj = extmain.signal"signal_arg0"
   var signal_arg1_obj = extmain.signal"signal_arg1"

--- a/test/nim/src/classes/gdextnode/typedef.nim
+++ b/test/nim/src/classes/gdextnode/typedef.nim
@@ -1,6 +1,5 @@
 import std/unittest
 import std/tables
-import std/strformat except `&`
 import std/strutils
 
 import gdext
@@ -23,12 +22,12 @@ import gdextgen/classes/[
 # because the program will finally be shared object(dll).
 unittest.disableParamFiltering()
 
-type GDExtNode* = ref object of Node
+type GDExtNode* = ptr object of Node
   initialized: bool
   texture: gdref Texture2D
 
 # Override init hook to customize the behavior when the object is created.
-method init(self: GDExtNode) =
+method onInit(self: GDExtNode) =
   if unlikely(not self.initialized):
     self.initialized = true
   else:
@@ -62,6 +61,7 @@ proc test_Object(self: GDExtNode) =
     test "instantiate":
       let obj: Object = instantiate Object
       check CLASS_getObjectPtr(obj) != nil
+      destroy obj
 
     test "singleton":
       # `/T` is same as `T.singleton`
@@ -84,19 +84,12 @@ proc test_RefCounted(self: GDExtNode) =
 
 proc test_Node(self: GDExtNode) =
   suite "Node":
-    # Shorthand of that:
-    # let node1 = instantiate(Node2D)
-    # node1.name = "MyNode2D"
-    let node = instantiate(Node2D, "MyNode2D")
-    # No need to have `original Node2D` since ownership of node will pass to `self` when call `addChild`.
-    # Or you can call `release(original T): T` like:
-    # ```
-    # let node = original instantiate(Node2D, "MyNode2D")
-    # self.addChild release node
-    # ```
-    # to dispose ownership.
 
     test "get node from tree":
+      # Shorthand of that:
+      # let node1 = instantiate(Node2D)
+      # node1.name = "MyNode2D"
+      let node = instantiate(Node2D, "MyNode2D")
       self.addChild node
 
       let node2_node: Node = self/"MyNode2D"
@@ -104,10 +97,6 @@ proc test_Node(self: GDExtNode) =
 
       let node2: Node2D = node2_node as Node2D
       check node == node2
-
-    test "stringify":
-      print fmt"{node=}"
-      check "MyNode2D" in $node
 
     test "get node from tree (using sugar)":
       let node = instantiate(Node2D, "Node2D")

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -4,7 +4,7 @@ import gdextgen/classes/gdResourceLoader
 type PropTestEnum* = enum
   PropTestEnum1, PropTestEnum2, PropTestEnum3
 
-type PropTestNode* = ref object of Node
+type PropTestNode* = ptr object of Node
   icon*: gdref Texture2D
   PropTestEnum_with_export*: PropTestEnum
   string_with_export*: string = "with export"
@@ -33,7 +33,7 @@ MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT"""
   color_with_export*: Color = color(1, 1, 1, 0.5)
   color_with_export_no_alpha*: Color = color(1, 1, 1)
 
-method init(self: PropTestNode) =
+method onInit(self: PropTestNode) =
   self.icon = ResourceLoader.load("res://icon.png") as gdref Texture2D
   self.StringArray_with_export_multiline = typedArray[String](1)
   self.PackedStringArray_with_export_multiline = packedStringArray()

--- a/test/nim/src/classes/gdtestobject.nim
+++ b/test/nim/src/classes/gdtestobject.nim
@@ -1,4 +1,4 @@
 import gdext
 
-type TestObject* = ref object of Object
+type TestObject* = ptr object of Object
 


### PR DESCRIPTION
In gdext-nim, all classes were previously defined as `ref object`. Internally, however, the object was protected from being destroyed until requested by the engine.
This can be replaced by using `ptr object, with removing the protection algorithm.

That has also a usability problem. It gives the misconception that it will be properly GC'd by Nim's memory management model.

In summary, Replace `ref object` with `ptr object` for two reasons: “extra overhead to the program” and “misunderstanding to the user” by using ref.