### PR TITLE
Invert dependency with gdextgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,9 @@ See [wiki][2] to get more detail.
 
 ```
 # install
-nimble install https://github.com/godot-nim/gdext-nim
+nimble install https://github.com/godot-nim/gdextgen
 
 # uninstall
-nimble uninstall gdext
 gdextwiz uninstall
 
 # upgrade

--- a/gdext.nimble
+++ b/gdext.nimble
@@ -2,7 +2,7 @@
 
 version       = "0.1.0"
 author        = "godot-nim, la.panon."
-description   = "Front-end library of godot-nim"
+description   = "core library of nim for gdextension. Do not stands alone."
 license       = "MIT"
 srcDir        = "src"
 installExt   = @["nim"]
@@ -13,7 +13,3 @@ binDir        = "bin"
 # Dependencies
 
 requires "nim >= 2.0.0"
-
-
-# Generated layer of gdext that defines the behavior of classes and structures.
-requires "https://github.com/godot-nim/gdextgen#head"

--- a/src/gdext.nim
+++ b/src/gdext.nim
@@ -14,19 +14,17 @@ export              builtinindex, geometrics, gdrefs, gdtypedarray
 import gdext/core/typeshift
 export typeshift.get, typeshift.variant
 
-import gdextgen/[ builtinclasses, classindex, globalenums, localenums, structs ]
-export            builtinclasses, classindex, globalenums, localenums, structs
+import gdext/surface/[ builtinclasses, classindex, globalenums, localenums, structs ]
+export                 builtinclasses, classindex, globalenums, localenums, structs
 
-import gdextgen/utilityfuncs
+import gdext/surface/utilityfuncs
 export utilityfuncs except print
-
-import gdextgen/classes/gdengine
-export gdengine.isEditorHint
 
 import gdext/surface/[ init, userclass, userenums, properties, classutils, variantutils, nodeutils, arrayutils, refutils, conversions ]
 export                 init, userclass, userenums, properties, classutils, variantutils, nodeutils, arrayutils, refutils, conversions
 
-import gdext/gdextensionmain
+import gdext/classes/[gdengine, gdextensionmain]
+export gdengine.isEditorHint
 export gdextensionmain.ExtensionMain, gdextensionmain.extmain
 
 proc print*(args: varargs[Variant, variant]) =

--- a/src/gdext/buildconf.nim
+++ b/src/gdext/buildconf.nim
@@ -103,5 +103,6 @@ else:
   # is required to activate this `. *` operator.
   --define: nimPreviewDotLikeOps
 
-  Extension.version = (4, 3)
   Extension.libdir = "$projectdir/lib"/RunningSystem/Build
+
+  include gdext/core/versiondata

--- a/src/gdext/classes/gdextensionmain.nim
+++ b/src/gdext/classes/gdextensionmain.nim
@@ -1,7 +1,6 @@
 import gdext/core/[gdclass]
-import gdextgen/[classindex]
-import gdextgen/classes/[gdengine]
-import gdext/surface/[userclass, classutils]
+import gdext/classes/[gdengine]
+import gdext/surface/[classindex, userclass, classutils]
 import gdext/buildconf
 
 import std/macros

--- a/src/gdext/core/userclass/propertyinfo.nim
+++ b/src/gdext/core/userclass/propertyinfo.nim
@@ -6,7 +6,7 @@ import gdext/core/extracommands
 import gdext/core/gdclass
 import gdext/core/gdrefs
 import gdext/core/typeshift
-import gdextgen/globalenums except VariantType
+import gdext/surface/globalenums except VariantType
 
 type
   GodotUnboundSymbolDefect* = object of Defect

--- a/src/gdext/core/userclass/signals.nim
+++ b/src/gdext/core/userclass/signals.nim
@@ -7,7 +7,7 @@ import gdext/core/builtinindex
 import gdext/core/commandindex
 import gdext/core/typeshift
 
-import gdextgen/classes/gdobject
+import gdext/classes/gdobject
 
 import contracts
 import propertyinfo

--- a/src/gdext/surface/arrayutils.nim
+++ b/src/gdext/surface/arrayutils.nim
@@ -3,7 +3,7 @@ import gdext/core/gdtypedarray
 import gdext/core/builtinindex
 import gdext/core/gdclass
 import gdext/core/typeshift
-import gdextgen/builtinclasses
+import gdext/surface/[builtinclasses]
 
 {.push, inline.}
 proc setLen*(arr: var Array; newlen: Natural) =

--- a/src/gdext/surface/conversions.nim
+++ b/src/gdext/surface/conversions.nim
@@ -1,7 +1,7 @@
 import gdext/core/builtinindex
 import gdext/core/gdclass
 import gdext/core/gdtypedarray
-import gdextgen/builtinclasses/constructors
+import gdext/surface/builtinclasses
 import gdext/surface/classutils
 import gdext/surface/variantutils
 

--- a/src/gdext/surface/init.nim
+++ b/src/gdext/surface/init.nim
@@ -7,10 +7,10 @@ import gdext/core/commandindex
 import gdext/core/extracommands
 import gdext/core/typeshift
 import gdext/core/exceptions
-import gdextgen/utilityfuncs
 import gdext/core/userclass/contracts
+import gdext/surface/utilityfuncs
 import gdext/surface/userclass
-import gdext/gdextensionmain
+import gdext/classes/gdextensionmain
 import gdext/buildconf
 
 

--- a/src/gdext/surface/nodeutils.nim
+++ b/src/gdext/surface/nodeutils.nim
@@ -1,9 +1,8 @@
 import std/macros
 
 import gdext/core/builtinindex
-import gdextgen/builtinclasses/constructors
-import gdextgen/classindex
-import gdextgen/classes/gdNode
+import gdext/surface/[builtinclasses, classindex]
+import gdext/classes/gdNode
 
 import classutils
 

--- a/src/gdext/surface/properties.nim
+++ b/src/gdext/surface/properties.nim
@@ -7,13 +7,12 @@ import gdext/core/commandindex
 import gdext/core/extracommands
 import gdext/core/gdclass
 import gdext/core/builtinindex
-import gdextgen/builtinclasses
-import gdextgen/globalenums
-import gdextgen/classindex
 
 import gdext/core/userclass/contracts
 import gdext/core/userclass/propertyinfo
 import gdext/core/userclass/procs
+
+import gdext/surface/[globalenums, builtinclasses, classindex]
 
 proc register_property_internal*(
       info: PropertyInfo;

--- a/src/gdext/wizard/subcommands/library.nim
+++ b/src/gdext/wizard/subcommands/library.nim
@@ -4,7 +4,7 @@ import std/strutils
 import std/parseopt
 
 const path = (
-  gdext: "https://github.com/godot-nim/gdext-nim",
+  gdext: "https://github.com/godot-nim/gdextgen",
 )
 
 proc install*(): 0..1 =
@@ -13,10 +13,8 @@ proc install*(): 0..1 =
 proc uninstall*(): 0..1 =
 
   let pkglist = @[
-    "gdext",
     "gdextgen",
-    "gdext/core",
-    "gdextwiz",
+    "gdext",
     ]
   let pkg = pkglist.join(" ")
 

--- a/test/nim/src/classes/gdextnode/typedef.nim
+++ b/test/nim/src/classes/gdextnode/typedef.nim
@@ -8,7 +8,7 @@ import gdext/core/[gdclass, typeshift]
 
 # sugar of `import godot/classDetail/classDetail_native_T`
 # Since this library is still early stage, we recommend to use this sugar for portability
-import gdextgen/classes/[
+import gdext/classes/[
   gdSceneTree,
   gdNode,
   gdRefCounted,

--- a/test/nim/src/classes/gdproptestnode.nim
+++ b/test/nim/src/classes/gdproptestnode.nim
@@ -1,5 +1,5 @@
 import gdext
-import gdextgen/classes/gdResourceLoader
+import gdext/classes/gdResourceLoader
 
 type PropTestEnum* = enum
   PropTestEnum1, PropTestEnum2, PropTestEnum3


### PR DESCRIPTION
Reverses the dependency between gdextgen and gdext and changes the gdextgen installation to require gdext.
In the previous package configuration, it was difficult to switch between target engine versions.
That would be accomplished by changing gdextgen, but that is not possible because a fixed version of gdextgen is required by gdext. Every time you tried to switch versions, you had to rewrite the requires in gdext.nimble and had to use `git clone` instead of `nimble install` for that.

With this PR, to switch versions, simply uninstall the current gdextgen (at this point, gdext will remain in local) and reinstall another gdextgen.

Furthermore, the root directory of the gdextgen package was changed to gdext. This allows, for example, when importing a class, to simply write `import gdext/classes/gdNode`, reducing confusion for the user and allowing for package abstraction.