### PR TITLE
Add editor commands

### DIFF
--- a/src/gdext/gdextwiz.nim
+++ b/src/gdext/gdextwiz.nim
@@ -38,8 +38,12 @@ Usage:
     build (nim-option...) (<at=$PWD>)
       : Search bootstrap.nim from <at> to '/' and compile it.
       : If project.godot is found instead of bootstrap.nim, build-all is called.
+    editor (<at=$PWD>)
+      : Search project.godot from <at> to '/' and launch editor
     run (nim-option...) (<at=$PWD>)
-      : After build-all, exec godot.
+      : After build, exec godot.
+    run-editor (nim-option...) (<at=$PWD>)
+      : After build, launch editor.
 
 Extending gdextwiz:
 
@@ -88,8 +92,12 @@ proc dispatch_subcmd(opt: var OptParser) =
         dispatch_build(opt)
       of "buildall":
         dispatch_build_all(opt)
+      of "editor":
+        dispatch_editor(opt)
       of "run":
         dispatch_run(opt)
+      of "runeditor":
+        dispatch_run_editor(opt)
       of "newextension":
         dispatch_new_extension(opt)
       else:

--- a/src/gdext/wizard/subcommands/iteration.nim
+++ b/src/gdext/wizard/subcommands/iteration.nim
@@ -22,74 +22,102 @@ proc build_recursive(cli: var CliContext; nimargs: seq[string], current: string;
     of pcDir, pcLinkToDir:
       interrupt cli.build_recursive(nimargs, path, limit.pred)
 
-proc build_all*(nimargs: seq[string]; search_path: string; depth: int; run: bool = false): 0..1 =
-  var cli = CliContext(wizard: "wizard build-all*")
-  var current = expandFilename search_path
-  while not fileExists(current/"project.godot"):
+proc getParent*(cli: var CliContext; search_from: string; files: varargs[string]): tuple[dir, file: string] =
+  var current = expandFilename search_from
+  while true:
+    for file in files:
+      if fileExists current/file:
+        return (current, file)
     if current == "/":
-      cli.failure "project.godot not found."
+      cli.failure files.join(", ") & " not found."
       quit 1
     current = expandFilename current/".."
 
-  cli.info "using " & current/"project.godot"
-  interrupt cli.build_recursive(nimargs, current, depth)
+proc getProjectRoot*(cli: var CliContext; search_from: string): string =
+  cli.getParent(search_from, "project.godot").dir
 
-  if run:
-    let exe = findExe("godot")
-    if exe.len == 0:
-      cli.failure "failed to run. godot executable not found."
-      quit 1
-    cli.info "godot executable found. launching..."
-    interrupt execShellCmd(exe & " --path " & current)
+proc launchEditor*(cli: var CliContext; path: string; args: varargs[string]): 0..1 =
+  let exe = findExe("godot")
+  if exe.len == 0:
+    cli.failure "failed to run. godot executable not found."
+    quit 1
+  cli.info "godot executable found. launching..."
+  execShellCmd(exe & " --path " & path & " " & args.join(" "))
+
+proc build_all*(nimargs: seq[string]; search_path: string; depth: int): 0..1 =
+  var cli = CliContext(wizard: "wizard build-all*")
+  var projectRoot = cli.getProjectRoot(search_path)
+
+  cli.info "using " & projectRoot/"project.godot"
+  interrupt cli.build_recursive(nimargs, projectRoot, depth)
 
 proc build*(nimargs: seq[string]; search_path: string; depth: int): 0..1 =
   var cli = CliContext(wizard: "wizard build*")
-  var current = search_path
+  let (dir, file) = cli.getParent(search_path, "project.godot", "bootstrap.nim")
 
-  while not fileExists(current/"bootstrap.nim"):
-    if current == "/":
-      cli.failure "bootstrap.nim not found."
-      quit 1
-    elif fileExists(current/"project.godot"):
-      quit build_all(nimargs, current, depth)
-    current = expandFilename current/".."
+  case file
+  of "project.godot":
+    interrupt build_all(nimargs, dir, depth)
+  of "bootstrap.nim":
+    cli.info "using " & dir/file
+    interrupt nim_c(nimargs, dir/file)
 
-  cli.info "using " & current/"bootstrap.nim"
-  nim_c nimargs, current/"bootstrap.nim"
+proc run*(nimargs: seq[string]; search_path: string; depth: int): 0..1 =
+  var cli = CliContext(wizard: "wizard run*")
+  let projectRoot = cli.getProjectRoot(search_path)
+  interrupt build(nimargs, search_path, depth)
+  cli.launchEditor(projectRoot)
+
+proc editor*(search_path: string): 0..1 =
+  var cli = CliContext(wizard: "wizard editor*")
+  let projectRoot = cli.getProjectRoot(search_path)
+  cli.launchEditor(projectRoot, "--editor")
+
+proc run_editor*(nimargs: seq[string]; search_path: string; depth: int): 0..1 =
+  interrupt build(nimargs, search_path, depth)
+  editor(search_path)
+
+type Command = proc (nimargs: seq[string]; search_path: string; depth: int): 0..1
+proc dispatch_iteration(opt: var OptParser; command: Command) =
+  next opt
+  var nimargs: seq[string]
+  var search_path = "."
+  var depth = int.high
+
+  while true:
+    case opt.kind
+    of cmdShortOption, cmdLongOption:
+      nimargs.add opt.reverseOpt
+    of cmdArgument:
+      search_path = opt.key
+      quit command(nimargs, search_path, depth)
+    of cmdEnd:
+      quit command(nimargs, search_path, depth)
+    next opt
 
 proc dispatch_build*(opt: var OptParser) =
-  next opt
-  var nimargs: seq[string]
-  var search_path = "."
-  var depth = int.high
+  dispatch_iteration(opt, build)
 
-  while true:
-    case opt.kind
-    of cmdShortOption, cmdLongOption:
-      nimargs.add opt.reverseOpt
-    of cmdArgument:
-      search_path = opt.key
-      quit build(nimargs, search_path, depth)
-    of cmdEnd:
-      quit build(nimargs, search_path, depth)
-    next opt
-
-proc dispatch_build_all*(opt: var OptParser; run = false) =
-  next opt
-  var nimargs: seq[string]
-  var search_path = "."
-  var depth = int.high
-
-  while true:
-    case opt.kind
-    of cmdShortOption, cmdLongOption:
-      nimargs.add opt.reverseOpt
-    of cmdArgument:
-      search_path = opt.key
-      quit build_all(nimargs, search_path, depth, run)
-    of cmdEnd:
-      quit build_all(nimargs, search_path, depth, run)
-    next opt
+proc dispatch_build_all*(opt: var OptParser) =
+  dispatch_iteration(opt, build_all)
 
 proc dispatch_run*(opt: var OptParser) =
-  dispatch_build_all(opt, true)
+  dispatch_iteration(opt, run)
+
+proc dispatch_editor*(opt: var OptParser) =
+  next opt
+  var search_path = "."
+
+  while true:
+    case opt.kind
+    of cmdShortOption, cmdLongOption:
+      discard
+    of cmdArgument:
+      search_path = opt.key
+      quit editor(search_path)
+    of cmdEnd:
+      quit editor(search_path)
+    next opt
+
+proc dispatch_run_editor*(opt: var OptParser) =
+  dispatch_iteration(opt, run_editor)


### PR DESCRIPTION
### Changes

* Change what the run command executes from build-all to build
* If the command fails midway, subsequent processing is aborted.

  Example: If the build of an extension fails during the execution of the run command, godot is not started.

### New

* `gdextwiz editor`
  Find project.godot in the direction of the parent directory and run godot --editor.
* `gdextwiz run-editor`
  After `run`, exec `editor`.