### PR TITLE
Feat(library): support to export varargs[ptr Variant]

### DIFF
--- a/src/gdext/core/typeshift.nim
+++ b/src/gdext/core/typeshift.nim
@@ -79,6 +79,8 @@ template variantType*(Type: typedesc[AltInt]): Variant_Type = VariantType_Int
 template variantType*(Type: typedesc[AltFloat]): Variant_Type = VariantType_Float
 template variantType*(Type: typedesc[AltString]): Variant_Type = VariantType_String
 
+template variantType*(Type: typedesc[ptr Variant]): Variant_Type = VariantType_Nil
+
 # General
 # =======
 
@@ -155,6 +157,16 @@ convert_generics_forcecast enum, Int
 convert_generic_params_forcecast set, Int
 convert_generic_params_forcecast TypedArray, Array
 
+# Variant
+# =======
+template encoded*(T: typedesc[Variant]): typedesc[Variant] = Variant
+template encode*(v: Variant; p: pointer) =
+  cast[ptr Variant](p)[] = v
+template decode*(p: pointer; T: typedesc[Variant]): T =
+  cast[ptr Variant](p)[]
+template variant*(v: Variant): Variant = v
+template get*(v: Variant; T: typedesc[Variant]): T = v
+
 
 # pointer
 # =======
@@ -169,16 +181,6 @@ template encode*[T](v: ptr T; p: pointer) =
   cast[ptr ptr T](p)[] = v
 proc decode*[T](p: pointer; _: typedesc[ptr T]): ptr T =
   cast[ptr T](p)
-
-# Variant
-# =======
-template encoded*(T: typedesc[Variant]): typedesc[Variant] = Variant
-template encode*(v: Variant; p: pointer) =
-  cast[ptr Variant](p)[] = v
-template decode*(p: pointer; T: typedesc[Variant]): T =
-  cast[ptr Variant](p)[]
-template variant*(v: Variant): Variant = v
-template get*(v: Variant; T: typedesc[Variant]): T = v
 
 # ObjectPtr
 # =========

--- a/src/gdext/core/userclass/methodinfo.nim
+++ b/src/gdext/core/userclass/methodinfo.nim
@@ -14,6 +14,7 @@ import propertyinfo
 type MiddleExp = object
   name: NimNode
   isStatic: bool
+  isVarargs: bool
   self_T: NimNode
   result_T: NimNode
   args: seq[tuple[namesym, typesym, default: NimNode]]
@@ -26,12 +27,14 @@ proc parseMiddle(procdef: NimNode): MiddleExp =
   if procdef.hasReturn:
     result.result_T = procdef.params[0]
 
-  result.args = procdef.params.breakArgs.toSeq
-    .filterIt(it.index != 0)
-    .mapIt((
-      it.def.name,
-      (if it.def.Type.kind == nnkEmpty: ident"typeof".newCall(it.def.default) else: it.def.Type),
-      it.def.default))
+  for i, (sym, typ, default) in procdef.params.breakArgs:
+    if i == 0: continue
+    if typ.isVarargs:
+      result.isVarargs = true
+    result.args.add (
+      sym,
+      (if typ.kind == nnkEmpty: ident"typeof".newCall(default) else: typ),
+      default)
 
   result.is_static = `and`(
     result.self_T.kind == nnkBracketExpr,
@@ -117,7 +120,6 @@ proc callFunc(middle: MiddleExp): NimNode =
   let self_T = middle.self_T
 
   let call = middle.name.newCall()
-  let options = newStmtList()
 
   if middle.is_static:
     call.add middle.self_T
@@ -127,28 +129,27 @@ proc callFunc(middle: MiddleExp): NimNode =
   for i, (name, Type, default) in middle.args:
     let i_lit = newlit i
 
-    if default.kind == nnkEmpty:
+    if Type.isVarargs:
+      call.add quote do:
+        cast[ptr UncheckedArray[ptr Variant]](`p_args`).toOpenArray(`i_lit`, `p_argument_count`.pred)
+
+    elif default.kind == nnkEmpty:
       call.add quote do: cast[ptr Variant](`p_args`[`i_lit`])[].get(typedesc `Type`)
     else:
-      let n = gensym(nskLet, $name)
-      options.add quote do:
-        let `n` =
-          if `p_argument_count` > `i_lit`:
-            cast[ptr Variant](`p_args`[`i_lit`])[].get(typedesc `Type`)
-          else: `default`
-      call.add n
+      call.add quote do:
+        if `p_argument_count` > `i_lit`:
+          cast[ptr Variant](`p_args`[`i_lit`])[].get(typedesc `Type`)
+        else: `default`
 
   let body =
     if middle.hasResult:
       quote do:
         errproof:
-          `options`
           let result = variant `call`
           interface_Variant_newCopy(`r_return`, addr result)
     else:
       quote do:
         errproof:
-          `options`
           let result = variant(); `call`
           interface_Variant_newCopy(`r_return`, addr result)
 
@@ -157,6 +158,8 @@ proc callFunc(middle: MiddleExp): NimNode =
       `body`
 
 proc ptrCallFunc(middle: MiddleExp): NimNode =
+  if middle.isVarargs: return newNilLit()
+
   let p_instance = ident"p_instance"
   let p_args = ident"p_args"
   let r_ret = ident"r_ret"

--- a/src/gdext/core/userclass/methodinfo.nim
+++ b/src/gdext/core/userclass/methodinfo.nim
@@ -193,7 +193,10 @@ proc flags(middle: MiddleExp): NimNode =
   result = newNimNode nnkCurly
   if middle.is_static:
     result.add bindSym"MethodFlag_Static"
-  else:
+  if middle.is_varargs:
+    result.add bindSym"MethodFlag_Vararg"
+
+  if result.len == 0:
     result.add bindSym"MethodFlag_Normal"
 
 

--- a/src/gdext/core/userclass/procs.nim
+++ b/src/gdext/core/userclass/procs.nim
@@ -74,9 +74,6 @@ proc sync_procDef*(procdef: NimNode): NimNode =
       if typ.kind == nnkEmpty: ident"typeof".newCall(default)
       else: typ
     if argT.isVarargs:
-      # TODO: remove this limitation.
-      if argT[1].repr != "ptr Variant":
-        error "invalid form; currently, varargs must be `ptr Variant`.", argT[1]
       varargsFound = true
       argT = argT[1]
     result.add nnkElifBranch.newTree(

--- a/src/gdext/core/userclass/propertyinfo.nim
+++ b/src/gdext/core/userclass/propertyinfo.nim
@@ -108,3 +108,11 @@ proc propertyInfo*[T: SomeProperty](_: typedesc[T];
     hint_string,
     usage + T.uniqueUsage,
   )
+
+proc propertyInfo*[T: SomeProperty](_: typedesc[varargs[T]];
+      name: ptr StringName = addr StringName.empty;
+      hint: PropertyHint = propertyHint_None;
+      hint_string: ptr String = addr String.empty;
+      usage: system.set[PropertyUsageFlags] = PropertyUsageFlags.propertyUsageDefault;
+    ): PropertyInfo =
+  propertyInfo(typedesc T, name, hint, hint_string, usage)

--- a/src/gdext/utils/macros.nim
+++ b/src/gdext/utils/macros.nim
@@ -80,6 +80,13 @@ func recList*(node: NimNode): NimNode =
   else:
     node.objectTy.recList
 
+func isVarargs*(node: NimNode): bool =
+  case node.kind
+  of nnkBracketExpr:
+    node[0].eqIdent "varargs"
+  else:
+    false
+
 proc super*(typedes: NimNode): NimNode =
   var
     cache {.global.}: Table[NimNode, NimNode]

--- a/test/nim/src/classes/gdextnode/functions.nim
+++ b/test/nim/src/classes/gdextnode/functions.nim
@@ -39,3 +39,5 @@ proc default_value_complex(self: GDExtNode;
 
 proc varargs_simple(self: GDExtNode; args: varargs[ptr Variant]): string {.gdsync.} =
   args.mapIt(it[].get int).join(", ")
+proc varargs_static(self: typedesc[GDExtNode]; args: varargs[ptr Variant]): string {.gdsync.} =
+  args.mapIt(it[].get int).join(", ")

--- a/test/nim/src/classes/gdextnode/functions.nim
+++ b/test/nim/src/classes/gdextnode/functions.nim
@@ -41,3 +41,6 @@ proc varargs_simple(self: GDExtNode; args: varargs[ptr Variant]): string {.gdsyn
   args.mapIt(it[].get int).join(", ")
 proc varargs_static(self: typedesc[GDExtNode]; args: varargs[ptr Variant]): string {.gdsync.} =
   args.mapIt(it[].get int).join(", ")
+
+proc varargs_concrete(self: GDExtNode; args: varargs[int]): string {.gdsync.} =
+  args.join(", ")

--- a/test/nim/src/classes/gdextnode/functions.nim
+++ b/test/nim/src/classes/gdextnode/functions.nim
@@ -1,3 +1,4 @@
+import std/[sequtils, strutils]
 import gdext
 import typedef
 
@@ -35,3 +36,6 @@ proc default_value_complex(self: GDExtNode;
       str4 = "value";
     ): string {.gdsync.} =
   "default_value_complex(" & str1 & " " & str2 & " " & str3 & " " & str4 & ")"
+
+proc varargs_simple(self: GDExtNode; args: varargs[ptr Variant]): string {.gdsync.} =
+  args.mapIt(it[].get int).join(", ")

--- a/test/nim/src/classes/gdextnode/functions.nim
+++ b/test/nim/src/classes/gdextnode/functions.nim
@@ -44,3 +44,11 @@ proc varargs_static(self: typedesc[GDExtNode]; args: varargs[ptr Variant]): stri
 
 proc varargs_concrete(self: GDExtNode; args: varargs[int]): string {.gdsync.} =
   args.join(", ")
+
+proc most_complex(self: GDExtNode;
+      str1, str2: string;
+      str3: string = "default";
+      str4 = "value";
+      args: varargs[string]
+    ): string {.gdsync.} =
+  @[str1, str2, str3, str4].concat(@args).join(" ")

--- a/test/tester.gd
+++ b/test/tester.gd
@@ -27,6 +27,7 @@ func test_func():
 
 	assert(node.varargs_simple(1, 2, 3, 4, 5) == "1, 2, 3, 4, 5")
 	assert(GDExtNode.varargs_static(1, 2, 3, 4, 5) == "1, 2, 3, 4, 5")
+	assert(node.varargs_concrete(1, 2, 3, 4, 5) == "1, 2, 3, 4, 5")
 
 func test_grobal_func():
 	GdextTester.signal_arg0.connect(_on_nim_signal_arg0)

--- a/test/tester.gd
+++ b/test/tester.gd
@@ -26,6 +26,7 @@ func test_func():
 	assert(node.default_value_complex("a", "b", "c", "d") == "default_value_complex(a b c d)")
 
 	assert(node.varargs_simple(1, 2, 3, 4, 5) == "1, 2, 3, 4, 5")
+	assert(GDExtNode.varargs_static(1, 2, 3, 4, 5) == "1, 2, 3, 4, 5")
 
 func test_grobal_func():
 	GdextTester.signal_arg0.connect(_on_nim_signal_arg0)

--- a/test/tester.gd
+++ b/test/tester.gd
@@ -25,6 +25,8 @@ func test_func():
 	assert(node.default_value_complex("a", "b", "c") == "default_value_complex(a b c value)")
 	assert(node.default_value_complex("a", "b", "c", "d") == "default_value_complex(a b c d)")
 
+	assert(node.varargs_simple(1, 2, 3, 4, 5) == "1, 2, 3, 4, 5")
+
 func test_grobal_func():
 	GdextTester.signal_arg0.connect(_on_nim_signal_arg0)
 	GdextTester.signal_arg1.connect(_on_nim_signal_arg1)

--- a/test/tester.gd
+++ b/test/tester.gd
@@ -29,6 +29,8 @@ func test_func():
 	assert(GDExtNode.varargs_static(1, 2, 3, 4, 5) == "1, 2, 3, 4, 5")
 	assert(node.varargs_concrete(1, 2, 3, 4, 5) == "1, 2, 3, 4, 5")
 
+	assert(node.most_complex("a", "b", "c", "d", "e", "f", "g") == "a b c d e f g")
+
 func test_grobal_func():
 	GdextTester.signal_arg0.connect(_on_nim_signal_arg0)
 	GdextTester.signal_arg1.connect(_on_nim_signal_arg1)


### PR DESCRIPTION
### Overview

```nim
proc varargs_variant(self: typedesc[GDExtNode]; args: varargs[ptr Variant]): string {.gdsync.} =
  args.mapIt(it[].get int).join(", ")
proc varargs_concrete(self: typedesc[GDExtNode]; args: varargs[int]): string {.gdsync.} =
  args.join(", ")

```

```gdscript
assert(GDExtNode.varargs_variant(1, 2, 3, 4, 5) == "1, 2, 3, 4, 5")
assert(GDExtNode.varargs_concrete(1, 2, 3, 4, 5) == "1, 2, 3, 4, 5")
```