### PR TITLE
Fix compilation problems on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,29 +66,6 @@ gdextwiz upgrade
 
   Choose a branch that has same name of your godot version.
 
-#### Windows (Optional)
-
-The mingw gcc bundled with Nim is not compatible with the godot engine. If it does not work, try one of the options.
-
-* [LLVM-MinGW][4]
-
-  Unzip llvm-mingw-YYYYMMDD-ucrt-x86_64.zip from [releases][5] and add bin to PATH.
-
-  And then, add `--cc: clang` to your `config.nims`.
-
-* [Build Tools for Visual Studio 2022][6]
-
-  Please install Build Tools for Visual Studio 2022 from here: https://aka.ms/vs/17/release/vs_BuildTools.exe.
-  Be sure that [Desktop development with C++] is checked.
-
-  Then next, add the path to cl to the PATH variable.
-  The path will be probably that: `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.36.32532\bin\HostX64\x64`
-
-  Finally, add `--cc: vcc` to your `config.nims`.
-
 [1]: https://github.com/godot-nim/demo
 [2]: https://github.com/godot-nim/gdext-nim/wiki
 [3]: https://github.com/godot-nim/gdext-nim/wiki/gdextwiz
-[4]: https://www.mingw-w64.org/downloads/#llvm-mingw
-[5]: https://github.com/mstorsjo/llvm-mingw/releases
-[6]: https://visualstudio.microsoft.com/downloads/

--- a/src/gdext/buildconf.nim
+++ b/src/gdext/buildconf.nim
@@ -103,6 +103,16 @@ else:
   # is required to activate this `. *` operator.
   --define: nimPreviewDotLikeOps
 
+  when hostOS == "windows":
+    # When using mingw32-gcc bundled with choosenim, it fails to load the linked
+    # dependent dynamic libraries. The solution is to link the libraries statically.
+
+    # TODO: This block is irrelevant depending on vcc and the gcc used, and requires
+    #       a mechanism to be able to disable it.
+
+    # --passL: "-static"
+    --passL: "-static-libgcc"
+
   Extension.libdir = "$projectdir/lib"/RunningSystem/Build
 
   include gdext/core/versiondata

--- a/test/nim/tests.gdextension
+++ b/test/nim/tests.gdextension
@@ -7,9 +7,9 @@ reloadable = true
 [libraries]
 
 linux.debug = "res://nim/lib/linux/debug/libbootstrap.so"
-windows.debug = "res://nim/lib/windows/debug/libbootstrap.dll"
+windows.debug = "res://nim/lib/windows/debug/bootstrap.dll"
 macos.debug = "res://./nim/lib/macos/debug/libbootstrap.dylib"
 
 linux.release = "res://nim/lib/linux/release/libbootstrap.so"
-windows.release = "res://nim/lib/windows/release/libbootstrap.dll"
+windows.release = "res://nim/lib/windows/release/bootstrap.dll"
 macos.release = "res://./nim/lib/macos/release/libbootstrap.dylib"


### PR DESCRIPTION
### Background

When using mingw32-gcc bundled with choosenim, it fails to load the linked dependent dynamic libraries. The solution is to link the libraries statically.