### PR TITLE
Vector field access

### DIFF
--- a/src/gdext/core/geometrics/typedef.nim
+++ b/src/gdext/core/geometrics/typedef.nim
@@ -1,4 +1,4 @@
-import std/macros
+import std/macros, std/genasts
 
 type
   Vector*[N: static int; T] = array[N, T]
@@ -8,6 +8,21 @@ type
 type
   Radian32* = Radian[float32]
   Radian64* = Radian[float64]
+
+macro genVecFieldAccess(): untyped =
+  const fields = ["x", "y", "z", "w"]
+  result = newStmtList()
+  let # this makes the generated code look nicer
+    vector = ident("vector")
+    value = ident("value")
+  for size in 2..4:
+    for fidx, fkey in fields.pairs:
+      if fidx >= size: break
+      let field = ident(fkey)
+      result.add genAst(size, fidx, field, vector, value) do:
+        template `field`*[T](vector: array[size, T]): T = vector[fidx]
+        template `field=`*[T](vector: var array[size, T], value: T) = vector[fidx] = value
+genVecFieldAccess()
 
 proc asNormalized*[N: static int; T: SomeFloat](vec: Vector[N,T]): NVector[N,T] {.inline.} = NVector[N,T](vec)
 

--- a/tests/testgeometrics.nim
+++ b/tests/testgeometrics.nim
@@ -1,4 +1,4 @@
-import std/unittest
+import std/unittest, std/math
 import gdext
 
 suite "Geometrics":
@@ -39,6 +39,46 @@ suite "Geometrics":
     check v345 - 10f == [-7f, -6, -5]
     check v345 * 10f == [30f, 40, 50]
     check v345 / 10f == [3/10f, 4/10f, 5/10f]
+
+  test "Vector field access":
+    var v2 = [1f, 2]
+    check compiles v2.x += 10
+    check compiles v2.y += 10
+    check not compiles v2.z += 10
+    check not compiles v2.w += 10
+
+    var v3 = [3, 4, 5] # int
+    check compiles v3.x += 10
+    check compiles v3.y -= 10
+    check compiles v3.z *= 10
+    check not compiles v3.w += 10
+    
+    var v4 = [6f, 7, 8, 9]
+    check compiles v4.x += 10
+    check compiles v4.y -= 10
+    check compiles v4.z *= 10
+    check compiles v4.w /= 10
+    
+    v2.x += 10
+    v2.y *= 10
+    check v2.x == 11
+    check v2.y == 20
+    
+    v3.x += 10
+    v3.y -= 10
+    v3.z *= 10
+    check v3.x == 13
+    check v3.y == -6
+    check v3.z == 50
+    
+    v4.x += 10
+    v4.y -= 10
+    v4.z *= 10
+    v4.w /= 10
+    check v4.x == 16
+    check v4.y == -3
+    check v4.z == 80
+    check v4.w.almostEqual 0.9
 
   test "normalize":
     check v012.dot(v345) == 14


### PR DESCRIPTION
Implements #109 

My originally suggested code worked fine, except `nim check` wouldn't detect `v2.z` as an error. Compiling would fail though. The same issue reemerged with the `compiles` check for the unittesting because it also wouldn't detect the error.

I tried using range[] generics but there might be nim bugs. I was able to contrive a working example, where `nim check` would detect incorrect access, but it didn't seem like a good idea to rely on potentially bugged code, and I believe `compiles` still accepted incorrect access.

I made an other version using `concept` but I don't have enough experience with them and wasn't able to consolidate them into a single generic concept type like I wanted.

In the end, I settled for a `macro` which simply generates the templates for the different combinations of vector 2, 3 and 4 with the appropriate x, y, z and w fields.