### PR TITLE
Fix indexed properties

### DIFF
--- a/coronation/src/coronation/operators/classes/properties.nim
+++ b/coronation/src/coronation/operators/classes/properties.nim
@@ -3,6 +3,7 @@ import ../classindex
 
 import submodules/wordropes
 import submodules/semanticstrings
+import operators/arguments
 
 import std/options
 import std/strformat
@@ -10,9 +11,16 @@ import std/strformat
 proc weave_properties*(class: Class): Cloth =
   weave margin:
     for prop in class.json.properties.get(@[]):
+      var typ =
+        if prop.index.isSome:
+          var metho = class.methods[prop.getter]
+          metho.arguments.get(@[])[0].convert().typeSym
+        else:
+          TypeSym.Void
+
       weave multiline:
-        let index_get = (if prop.index.isSome: $prop.index.get else: "")
-        let index_set = (if prop.index.isSome: $prop.index.get & ", " else: "")
+        let index_get = (if prop.index.isSome: &"{typ}({prop.index.get})" else: "")
+        let index_set = (if prop.index.isSome: index_get & ", " else: "")
         let name = prop.name.scan.convert(ProcSym)
         &"template {name}*(self: {class.typesym}): untyped = self.{prop.getter.scan.convert(ProcSym)}({index_get})"
         if prop.setter.isSome:

--- a/coronation/src/coronation/operators/classindex.nim
+++ b/coronation/src/coronation/operators/classindex.nim
@@ -8,9 +8,12 @@ import std/sets
 import std/tables
 import std/deques
 
+export tables
+
 type Class* = ref object
   typesym*, inherits*: TypeSym
   json*: JsonClass
+  methods*: Table[string, JsonClassMethod]
 type InheritanceDB = TableRef[TypeSym, HashSet[TypeSym]]
 
 let classDB* = new TableRef[TypeSym, Class]
@@ -23,6 +26,8 @@ proc convert*(json: JsonClass): Class =
     if json.inherits.isSome: json.inherits.get.scan.convert(TypeSym)
     else: TypeSym.RootObj
   result.json = json
+  for metho in json.methods.get(@[]):
+    result.methods[metho.name] = metho
 
 proc registerDB*(class: Class) =
   classDB[class.typesym] = class

--- a/src/gdext/classes.nim
+++ b/src/gdext/classes.nim
@@ -192,7 +192,6 @@ import ./classes/gddampedspringjoint2d; export gddampedspringjoint2d
 import ./classes/gddecal; export gddecal
 import ./classes/gddiraccess; export gddiraccess
 import ./classes/gddirectionallight2d; export gddirectionallight2d
-import ./classes/gddirectionallight3d; export gddirectionallight3d
 import ./classes/gddisplayserver; export gddisplayserver
 import ./classes/gddtlsserver; export gddtlsserver
 import ./classes/gdeditorcommandpalette; export gdeditorcommandpalette
@@ -262,7 +261,6 @@ import ./classes/gdfogmaterial; export gdfogmaterial
 import ./classes/gdfogvolume; export gdfogvolume
 import ./classes/gdfont; export gdfont
 import ./classes/gdfontfile; export gdfontfile
-import ./classes/gdfontvariation; export gdfontvariation
 import ./classes/gdframebuffercacherd; export gdframebuffercacherd
 import ./classes/gdgdextension; export gdgdextension
 import ./classes/gdgdextensionmanager; export gdgdextensionmanager
@@ -445,7 +443,6 @@ import ./classes/gdoccluderpolygon2d; export gdoccluderpolygon2d
 import ./classes/gdofflinemultiplayerpeer; export gdofflinemultiplayerpeer
 import ./classes/gdoggpacketsequence; export gdoggpacketsequence
 import ./classes/gdoggpacketsequenceplayback; export gdoggpacketsequenceplayback
-import ./classes/gdomnilight3d; export gdomnilight3d
 import ./classes/gdopenxraction; export gdopenxraction
 import ./classes/gdopenxractionmap; export gdopenxractionmap
 import ./classes/gdopenxractionset; export gdopenxractionset
@@ -668,7 +665,6 @@ import ./classes/gdsphereoccluder3d; export gdsphereoccluder3d
 import ./classes/gdsphereshape3d; export gdsphereshape3d
 import ./classes/gdspinbox; export gdspinbox
 import ./classes/gdsplitcontainer; export gdsplitcontainer
-import ./classes/gdspotlight3d; export gdspotlight3d
 import ./classes/gdspringarm3d; export gdspringarm3d
 import ./classes/gdsprite2d; export gdsprite2d
 import ./classes/gdsprite3d; export gdsprite3d
@@ -693,7 +689,6 @@ import ./classes/gdsubviewport; export gdsubviewport
 import ./classes/gdsubviewportcontainer; export gdsubviewportcontainer
 import ./classes/gdsurfacetool; export gdsurfacetool
 import ./classes/gdsyntaxhighlighter; export gdsyntaxhighlighter
-import ./classes/gdsystemfont; export gdsystemfont
 import ./classes/gdtabbar; export gdtabbar
 import ./classes/gdtabcontainer; export gdtabcontainer
 import ./classes/gdtcpserver; export gdtcpserver

--- a/src/gdext/classes/gdaudiostreamplaylist.nim
+++ b/src/gdext/classes/gdaudiostreamplaylist.nim
@@ -78,197 +78,197 @@ template `fadeTime=`*(self: AudioStreamPlaylist; value) = self.setFadeTime(value
 template streamCount*(self: AudioStreamPlaylist): untyped = self.getStreamCount()
 template `streamCount=`*(self: AudioStreamPlaylist; value) = self.setStreamCount(value)
 
-template stream0*(self: AudioStreamPlaylist): untyped = self.getListStream(0)
-template `stream0=`*(self: AudioStreamPlaylist; value) = self.setListStream(0, value)
+template stream0*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(0))
+template `stream0=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(0), value)
 
-template stream1*(self: AudioStreamPlaylist): untyped = self.getListStream(1)
-template `stream1=`*(self: AudioStreamPlaylist; value) = self.setListStream(1, value)
+template stream1*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(1))
+template `stream1=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(1), value)
 
-template stream2*(self: AudioStreamPlaylist): untyped = self.getListStream(2)
-template `stream2=`*(self: AudioStreamPlaylist; value) = self.setListStream(2, value)
+template stream2*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(2))
+template `stream2=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(2), value)
 
-template stream3*(self: AudioStreamPlaylist): untyped = self.getListStream(3)
-template `stream3=`*(self: AudioStreamPlaylist; value) = self.setListStream(3, value)
+template stream3*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(3))
+template `stream3=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(3), value)
 
-template stream4*(self: AudioStreamPlaylist): untyped = self.getListStream(4)
-template `stream4=`*(self: AudioStreamPlaylist; value) = self.setListStream(4, value)
+template stream4*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(4))
+template `stream4=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(4), value)
 
-template stream5*(self: AudioStreamPlaylist): untyped = self.getListStream(5)
-template `stream5=`*(self: AudioStreamPlaylist; value) = self.setListStream(5, value)
+template stream5*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(5))
+template `stream5=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(5), value)
 
-template stream6*(self: AudioStreamPlaylist): untyped = self.getListStream(6)
-template `stream6=`*(self: AudioStreamPlaylist; value) = self.setListStream(6, value)
+template stream6*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(6))
+template `stream6=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(6), value)
 
-template stream7*(self: AudioStreamPlaylist): untyped = self.getListStream(7)
-template `stream7=`*(self: AudioStreamPlaylist; value) = self.setListStream(7, value)
+template stream7*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(7))
+template `stream7=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(7), value)
 
-template stream8*(self: AudioStreamPlaylist): untyped = self.getListStream(8)
-template `stream8=`*(self: AudioStreamPlaylist; value) = self.setListStream(8, value)
+template stream8*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(8))
+template `stream8=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(8), value)
 
-template stream9*(self: AudioStreamPlaylist): untyped = self.getListStream(9)
-template `stream9=`*(self: AudioStreamPlaylist; value) = self.setListStream(9, value)
+template stream9*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(9))
+template `stream9=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(9), value)
 
-template stream10*(self: AudioStreamPlaylist): untyped = self.getListStream(10)
-template `stream10=`*(self: AudioStreamPlaylist; value) = self.setListStream(10, value)
+template stream10*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(10))
+template `stream10=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(10), value)
 
-template stream11*(self: AudioStreamPlaylist): untyped = self.getListStream(11)
-template `stream11=`*(self: AudioStreamPlaylist; value) = self.setListStream(11, value)
+template stream11*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(11))
+template `stream11=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(11), value)
 
-template stream12*(self: AudioStreamPlaylist): untyped = self.getListStream(12)
-template `stream12=`*(self: AudioStreamPlaylist; value) = self.setListStream(12, value)
+template stream12*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(12))
+template `stream12=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(12), value)
 
-template stream13*(self: AudioStreamPlaylist): untyped = self.getListStream(13)
-template `stream13=`*(self: AudioStreamPlaylist; value) = self.setListStream(13, value)
+template stream13*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(13))
+template `stream13=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(13), value)
 
-template stream14*(self: AudioStreamPlaylist): untyped = self.getListStream(14)
-template `stream14=`*(self: AudioStreamPlaylist; value) = self.setListStream(14, value)
+template stream14*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(14))
+template `stream14=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(14), value)
 
-template stream15*(self: AudioStreamPlaylist): untyped = self.getListStream(15)
-template `stream15=`*(self: AudioStreamPlaylist; value) = self.setListStream(15, value)
+template stream15*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(15))
+template `stream15=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(15), value)
 
-template stream16*(self: AudioStreamPlaylist): untyped = self.getListStream(16)
-template `stream16=`*(self: AudioStreamPlaylist; value) = self.setListStream(16, value)
+template stream16*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(16))
+template `stream16=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(16), value)
 
-template stream17*(self: AudioStreamPlaylist): untyped = self.getListStream(17)
-template `stream17=`*(self: AudioStreamPlaylist; value) = self.setListStream(17, value)
+template stream17*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(17))
+template `stream17=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(17), value)
 
-template stream18*(self: AudioStreamPlaylist): untyped = self.getListStream(18)
-template `stream18=`*(self: AudioStreamPlaylist; value) = self.setListStream(18, value)
+template stream18*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(18))
+template `stream18=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(18), value)
 
-template stream19*(self: AudioStreamPlaylist): untyped = self.getListStream(19)
-template `stream19=`*(self: AudioStreamPlaylist; value) = self.setListStream(19, value)
+template stream19*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(19))
+template `stream19=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(19), value)
 
-template stream20*(self: AudioStreamPlaylist): untyped = self.getListStream(20)
-template `stream20=`*(self: AudioStreamPlaylist; value) = self.setListStream(20, value)
+template stream20*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(20))
+template `stream20=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(20), value)
 
-template stream21*(self: AudioStreamPlaylist): untyped = self.getListStream(21)
-template `stream21=`*(self: AudioStreamPlaylist; value) = self.setListStream(21, value)
+template stream21*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(21))
+template `stream21=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(21), value)
 
-template stream22*(self: AudioStreamPlaylist): untyped = self.getListStream(22)
-template `stream22=`*(self: AudioStreamPlaylist; value) = self.setListStream(22, value)
+template stream22*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(22))
+template `stream22=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(22), value)
 
-template stream23*(self: AudioStreamPlaylist): untyped = self.getListStream(23)
-template `stream23=`*(self: AudioStreamPlaylist; value) = self.setListStream(23, value)
+template stream23*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(23))
+template `stream23=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(23), value)
 
-template stream24*(self: AudioStreamPlaylist): untyped = self.getListStream(24)
-template `stream24=`*(self: AudioStreamPlaylist; value) = self.setListStream(24, value)
+template stream24*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(24))
+template `stream24=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(24), value)
 
-template stream25*(self: AudioStreamPlaylist): untyped = self.getListStream(25)
-template `stream25=`*(self: AudioStreamPlaylist; value) = self.setListStream(25, value)
+template stream25*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(25))
+template `stream25=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(25), value)
 
-template stream26*(self: AudioStreamPlaylist): untyped = self.getListStream(26)
-template `stream26=`*(self: AudioStreamPlaylist; value) = self.setListStream(26, value)
+template stream26*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(26))
+template `stream26=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(26), value)
 
-template stream27*(self: AudioStreamPlaylist): untyped = self.getListStream(27)
-template `stream27=`*(self: AudioStreamPlaylist; value) = self.setListStream(27, value)
+template stream27*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(27))
+template `stream27=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(27), value)
 
-template stream28*(self: AudioStreamPlaylist): untyped = self.getListStream(28)
-template `stream28=`*(self: AudioStreamPlaylist; value) = self.setListStream(28, value)
+template stream28*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(28))
+template `stream28=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(28), value)
 
-template stream29*(self: AudioStreamPlaylist): untyped = self.getListStream(29)
-template `stream29=`*(self: AudioStreamPlaylist; value) = self.setListStream(29, value)
+template stream29*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(29))
+template `stream29=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(29), value)
 
-template stream30*(self: AudioStreamPlaylist): untyped = self.getListStream(30)
-template `stream30=`*(self: AudioStreamPlaylist; value) = self.setListStream(30, value)
+template stream30*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(30))
+template `stream30=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(30), value)
 
-template stream31*(self: AudioStreamPlaylist): untyped = self.getListStream(31)
-template `stream31=`*(self: AudioStreamPlaylist; value) = self.setListStream(31, value)
+template stream31*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(31))
+template `stream31=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(31), value)
 
-template stream32*(self: AudioStreamPlaylist): untyped = self.getListStream(32)
-template `stream32=`*(self: AudioStreamPlaylist; value) = self.setListStream(32, value)
+template stream32*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(32))
+template `stream32=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(32), value)
 
-template stream33*(self: AudioStreamPlaylist): untyped = self.getListStream(33)
-template `stream33=`*(self: AudioStreamPlaylist; value) = self.setListStream(33, value)
+template stream33*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(33))
+template `stream33=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(33), value)
 
-template stream34*(self: AudioStreamPlaylist): untyped = self.getListStream(34)
-template `stream34=`*(self: AudioStreamPlaylist; value) = self.setListStream(34, value)
+template stream34*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(34))
+template `stream34=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(34), value)
 
-template stream35*(self: AudioStreamPlaylist): untyped = self.getListStream(35)
-template `stream35=`*(self: AudioStreamPlaylist; value) = self.setListStream(35, value)
+template stream35*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(35))
+template `stream35=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(35), value)
 
-template stream36*(self: AudioStreamPlaylist): untyped = self.getListStream(36)
-template `stream36=`*(self: AudioStreamPlaylist; value) = self.setListStream(36, value)
+template stream36*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(36))
+template `stream36=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(36), value)
 
-template stream37*(self: AudioStreamPlaylist): untyped = self.getListStream(37)
-template `stream37=`*(self: AudioStreamPlaylist; value) = self.setListStream(37, value)
+template stream37*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(37))
+template `stream37=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(37), value)
 
-template stream38*(self: AudioStreamPlaylist): untyped = self.getListStream(38)
-template `stream38=`*(self: AudioStreamPlaylist; value) = self.setListStream(38, value)
+template stream38*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(38))
+template `stream38=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(38), value)
 
-template stream39*(self: AudioStreamPlaylist): untyped = self.getListStream(39)
-template `stream39=`*(self: AudioStreamPlaylist; value) = self.setListStream(39, value)
+template stream39*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(39))
+template `stream39=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(39), value)
 
-template stream40*(self: AudioStreamPlaylist): untyped = self.getListStream(40)
-template `stream40=`*(self: AudioStreamPlaylist; value) = self.setListStream(40, value)
+template stream40*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(40))
+template `stream40=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(40), value)
 
-template stream41*(self: AudioStreamPlaylist): untyped = self.getListStream(41)
-template `stream41=`*(self: AudioStreamPlaylist; value) = self.setListStream(41, value)
+template stream41*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(41))
+template `stream41=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(41), value)
 
-template stream42*(self: AudioStreamPlaylist): untyped = self.getListStream(42)
-template `stream42=`*(self: AudioStreamPlaylist; value) = self.setListStream(42, value)
+template stream42*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(42))
+template `stream42=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(42), value)
 
-template stream43*(self: AudioStreamPlaylist): untyped = self.getListStream(43)
-template `stream43=`*(self: AudioStreamPlaylist; value) = self.setListStream(43, value)
+template stream43*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(43))
+template `stream43=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(43), value)
 
-template stream44*(self: AudioStreamPlaylist): untyped = self.getListStream(44)
-template `stream44=`*(self: AudioStreamPlaylist; value) = self.setListStream(44, value)
+template stream44*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(44))
+template `stream44=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(44), value)
 
-template stream45*(self: AudioStreamPlaylist): untyped = self.getListStream(45)
-template `stream45=`*(self: AudioStreamPlaylist; value) = self.setListStream(45, value)
+template stream45*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(45))
+template `stream45=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(45), value)
 
-template stream46*(self: AudioStreamPlaylist): untyped = self.getListStream(46)
-template `stream46=`*(self: AudioStreamPlaylist; value) = self.setListStream(46, value)
+template stream46*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(46))
+template `stream46=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(46), value)
 
-template stream47*(self: AudioStreamPlaylist): untyped = self.getListStream(47)
-template `stream47=`*(self: AudioStreamPlaylist; value) = self.setListStream(47, value)
+template stream47*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(47))
+template `stream47=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(47), value)
 
-template stream48*(self: AudioStreamPlaylist): untyped = self.getListStream(48)
-template `stream48=`*(self: AudioStreamPlaylist; value) = self.setListStream(48, value)
+template stream48*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(48))
+template `stream48=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(48), value)
 
-template stream49*(self: AudioStreamPlaylist): untyped = self.getListStream(49)
-template `stream49=`*(self: AudioStreamPlaylist; value) = self.setListStream(49, value)
+template stream49*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(49))
+template `stream49=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(49), value)
 
-template stream50*(self: AudioStreamPlaylist): untyped = self.getListStream(50)
-template `stream50=`*(self: AudioStreamPlaylist; value) = self.setListStream(50, value)
+template stream50*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(50))
+template `stream50=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(50), value)
 
-template stream51*(self: AudioStreamPlaylist): untyped = self.getListStream(51)
-template `stream51=`*(self: AudioStreamPlaylist; value) = self.setListStream(51, value)
+template stream51*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(51))
+template `stream51=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(51), value)
 
-template stream52*(self: AudioStreamPlaylist): untyped = self.getListStream(52)
-template `stream52=`*(self: AudioStreamPlaylist; value) = self.setListStream(52, value)
+template stream52*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(52))
+template `stream52=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(52), value)
 
-template stream53*(self: AudioStreamPlaylist): untyped = self.getListStream(53)
-template `stream53=`*(self: AudioStreamPlaylist; value) = self.setListStream(53, value)
+template stream53*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(53))
+template `stream53=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(53), value)
 
-template stream54*(self: AudioStreamPlaylist): untyped = self.getListStream(54)
-template `stream54=`*(self: AudioStreamPlaylist; value) = self.setListStream(54, value)
+template stream54*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(54))
+template `stream54=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(54), value)
 
-template stream55*(self: AudioStreamPlaylist): untyped = self.getListStream(55)
-template `stream55=`*(self: AudioStreamPlaylist; value) = self.setListStream(55, value)
+template stream55*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(55))
+template `stream55=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(55), value)
 
-template stream56*(self: AudioStreamPlaylist): untyped = self.getListStream(56)
-template `stream56=`*(self: AudioStreamPlaylist; value) = self.setListStream(56, value)
+template stream56*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(56))
+template `stream56=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(56), value)
 
-template stream57*(self: AudioStreamPlaylist): untyped = self.getListStream(57)
-template `stream57=`*(self: AudioStreamPlaylist; value) = self.setListStream(57, value)
+template stream57*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(57))
+template `stream57=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(57), value)
 
-template stream58*(self: AudioStreamPlaylist): untyped = self.getListStream(58)
-template `stream58=`*(self: AudioStreamPlaylist; value) = self.setListStream(58, value)
+template stream58*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(58))
+template `stream58=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(58), value)
 
-template stream59*(self: AudioStreamPlaylist): untyped = self.getListStream(59)
-template `stream59=`*(self: AudioStreamPlaylist; value) = self.setListStream(59, value)
+template stream59*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(59))
+template `stream59=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(59), value)
 
-template stream60*(self: AudioStreamPlaylist): untyped = self.getListStream(60)
-template `stream60=`*(self: AudioStreamPlaylist; value) = self.setListStream(60, value)
+template stream60*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(60))
+template `stream60=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(60), value)
 
-template stream61*(self: AudioStreamPlaylist): untyped = self.getListStream(61)
-template `stream61=`*(self: AudioStreamPlaylist; value) = self.setListStream(61, value)
+template stream61*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(61))
+template `stream61=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(61), value)
 
-template stream62*(self: AudioStreamPlaylist): untyped = self.getListStream(62)
-template `stream62=`*(self: AudioStreamPlaylist; value) = self.setListStream(62, value)
+template stream62*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(62))
+template `stream62=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(62), value)
 
-template stream63*(self: AudioStreamPlaylist): untyped = self.getListStream(63)
-template `stream63=`*(self: AudioStreamPlaylist; value) = self.setListStream(63, value)
+template stream63*(self: AudioStreamPlaylist): untyped = self.getListStream(int32(63))
+template `stream63=`*(self: AudioStreamPlaylist; value) = self.setListStream(int32(63), value)
 
 const AudioStreamPlaylist_vmap =
   AudioStream.vmap.concat initTable[string, string]()

--- a/src/gdext/classes/gdbasematerial3d.nim
+++ b/src/gdext/classes/gdbasematerial3d.nim
@@ -779,8 +779,8 @@ template `cullMode=`*(self: BaseMaterial3D; value) = self.setCullMode(value)
 template depthDrawMode*(self: BaseMaterial3D): untyped = self.getDepthDrawMode()
 template `depthDrawMode=`*(self: BaseMaterial3D; value) = self.setDepthDrawMode(value)
 
-template noDepthTest*(self: BaseMaterial3D): untyped = self.getFlag(0)
-template `noDepthTest=`*(self: BaseMaterial3D; value) = self.setFlag(0, value)
+template noDepthTest*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(0))
+template `noDepthTest=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(0), value)
 
 template shadingMode*(self: BaseMaterial3D): untyped = self.getShadingMode()
 template `shadingMode=`*(self: BaseMaterial3D; value) = self.setShadingMode(value)
@@ -791,32 +791,32 @@ template `diffuseMode=`*(self: BaseMaterial3D; value) = self.setDiffuseMode(valu
 template specularMode*(self: BaseMaterial3D): untyped = self.getSpecularMode()
 template `specularMode=`*(self: BaseMaterial3D; value) = self.setSpecularMode(value)
 
-template disableAmbientLight*(self: BaseMaterial3D): untyped = self.getFlag(14)
-template `disableAmbientLight=`*(self: BaseMaterial3D; value) = self.setFlag(14, value)
+template disableAmbientLight*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(14))
+template `disableAmbientLight=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(14), value)
 
-template disableFog*(self: BaseMaterial3D): untyped = self.getFlag(21)
-template `disableFog=`*(self: BaseMaterial3D; value) = self.setFlag(21, value)
+template disableFog*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(21))
+template `disableFog=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(21), value)
 
-template vertexColorUseAsAlbedo*(self: BaseMaterial3D): untyped = self.getFlag(1)
-template `vertexColorUseAsAlbedo=`*(self: BaseMaterial3D; value) = self.setFlag(1, value)
+template vertexColorUseAsAlbedo*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(1))
+template `vertexColorUseAsAlbedo=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(1), value)
 
-template vertexColorIsSrgb*(self: BaseMaterial3D): untyped = self.getFlag(2)
-template `vertexColorIsSrgb=`*(self: BaseMaterial3D; value) = self.setFlag(2, value)
+template vertexColorIsSrgb*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(2))
+template `vertexColorIsSrgb=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(2), value)
 
 template albedoColor*(self: BaseMaterial3D): untyped = self.getAlbedo()
 template `albedoColor=`*(self: BaseMaterial3D; value) = self.setAlbedo(value)
 
-template albedoTexture*(self: BaseMaterial3D): untyped = self.getTexture(0)
-template `albedoTexture=`*(self: BaseMaterial3D; value) = self.setTexture(0, value)
+template albedoTexture*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(0))
+template `albedoTexture=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(0), value)
 
-template albedoTextureForceSrgb*(self: BaseMaterial3D): untyped = self.getFlag(12)
-template `albedoTextureForceSrgb=`*(self: BaseMaterial3D; value) = self.setFlag(12, value)
+template albedoTextureForceSrgb*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(12))
+template `albedoTextureForceSrgb=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(12), value)
 
-template albedoTextureMsdf*(self: BaseMaterial3D): untyped = self.getFlag(20)
-template `albedoTextureMsdf=`*(self: BaseMaterial3D; value) = self.setFlag(20, value)
+template albedoTextureMsdf*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(20))
+template `albedoTextureMsdf=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(20), value)
 
-template ormTexture*(self: BaseMaterial3D): untyped = self.getTexture(17)
-template `ormTexture=`*(self: BaseMaterial3D; value) = self.setTexture(17, value)
+template ormTexture*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(17))
+template `ormTexture=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(17), value)
 
 template metallic*(self: BaseMaterial3D): untyped = self.getMetallic()
 template `metallic=`*(self: BaseMaterial3D; value) = self.setMetallic(value)
@@ -824,8 +824,8 @@ template `metallic=`*(self: BaseMaterial3D; value) = self.setMetallic(value)
 template metallicSpecular*(self: BaseMaterial3D): untyped = self.getSpecular()
 template `metallicSpecular=`*(self: BaseMaterial3D; value) = self.setSpecular(value)
 
-template metallicTexture*(self: BaseMaterial3D): untyped = self.getTexture(1)
-template `metallicTexture=`*(self: BaseMaterial3D; value) = self.setTexture(1, value)
+template metallicTexture*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(1))
+template `metallicTexture=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(1), value)
 
 template metallicTextureChannel*(self: BaseMaterial3D): untyped = self.getMetallicTextureChannel()
 template `metallicTextureChannel=`*(self: BaseMaterial3D; value) = self.setMetallicTextureChannel(value)
@@ -833,14 +833,14 @@ template `metallicTextureChannel=`*(self: BaseMaterial3D; value) = self.setMetal
 template roughness*(self: BaseMaterial3D): untyped = self.getRoughness()
 template `roughness=`*(self: BaseMaterial3D; value) = self.setRoughness(value)
 
-template roughnessTexture*(self: BaseMaterial3D): untyped = self.getTexture(2)
-template `roughnessTexture=`*(self: BaseMaterial3D; value) = self.setTexture(2, value)
+template roughnessTexture*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(2))
+template `roughnessTexture=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(2), value)
 
 template roughnessTextureChannel*(self: BaseMaterial3D): untyped = self.getRoughnessTextureChannel()
 template `roughnessTextureChannel=`*(self: BaseMaterial3D; value) = self.setRoughnessTextureChannel(value)
 
-template emissionEnabled*(self: BaseMaterial3D): untyped = self.getFeature(0)
-template `emissionEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(0, value)
+template emissionEnabled*(self: BaseMaterial3D): untyped = self.getFeature(BaseMaterial3D_Feature(0))
+template `emissionEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(BaseMaterial3D_Feature(0), value)
 
 template emission*(self: BaseMaterial3D): untyped = self.getEmission()
 template `emission=`*(self: BaseMaterial3D; value) = self.setEmission(value)
@@ -854,23 +854,23 @@ template `emissionIntensity=`*(self: BaseMaterial3D; value) = self.setEmissionIn
 template emissionOperator*(self: BaseMaterial3D): untyped = self.getEmissionOperator()
 template `emissionOperator=`*(self: BaseMaterial3D; value) = self.setEmissionOperator(value)
 
-template emissionOnUv2*(self: BaseMaterial3D): untyped = self.getFlag(11)
-template `emissionOnUv2=`*(self: BaseMaterial3D; value) = self.setFlag(11, value)
+template emissionOnUv2*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(11))
+template `emissionOnUv2=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(11), value)
 
-template emissionTexture*(self: BaseMaterial3D): untyped = self.getTexture(3)
-template `emissionTexture=`*(self: BaseMaterial3D; value) = self.setTexture(3, value)
+template emissionTexture*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(3))
+template `emissionTexture=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(3), value)
 
-template normalEnabled*(self: BaseMaterial3D): untyped = self.getFeature(1)
-template `normalEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(1, value)
+template normalEnabled*(self: BaseMaterial3D): untyped = self.getFeature(BaseMaterial3D_Feature(1))
+template `normalEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(BaseMaterial3D_Feature(1), value)
 
 template normalScale*(self: BaseMaterial3D): untyped = self.getNormalScale()
 template `normalScale=`*(self: BaseMaterial3D; value) = self.setNormalScale(value)
 
-template normalTexture*(self: BaseMaterial3D): untyped = self.getTexture(4)
-template `normalTexture=`*(self: BaseMaterial3D; value) = self.setTexture(4, value)
+template normalTexture*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(4))
+template `normalTexture=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(4), value)
 
-template rimEnabled*(self: BaseMaterial3D): untyped = self.getFeature(2)
-template `rimEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(2, value)
+template rimEnabled*(self: BaseMaterial3D): untyped = self.getFeature(BaseMaterial3D_Feature(2))
+template `rimEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(BaseMaterial3D_Feature(2), value)
 
 template rim*(self: BaseMaterial3D): untyped = self.getRim()
 template `rim=`*(self: BaseMaterial3D; value) = self.setRim(value)
@@ -878,11 +878,11 @@ template `rim=`*(self: BaseMaterial3D; value) = self.setRim(value)
 template rimTint*(self: BaseMaterial3D): untyped = self.getRimTint()
 template `rimTint=`*(self: BaseMaterial3D; value) = self.setRimTint(value)
 
-template rimTexture*(self: BaseMaterial3D): untyped = self.getTexture(5)
-template `rimTexture=`*(self: BaseMaterial3D; value) = self.setTexture(5, value)
+template rimTexture*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(5))
+template `rimTexture=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(5), value)
 
-template clearcoatEnabled*(self: BaseMaterial3D): untyped = self.getFeature(3)
-template `clearcoatEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(3, value)
+template clearcoatEnabled*(self: BaseMaterial3D): untyped = self.getFeature(BaseMaterial3D_Feature(3))
+template `clearcoatEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(BaseMaterial3D_Feature(3), value)
 
 template clearcoat*(self: BaseMaterial3D): untyped = self.getClearcoat()
 template `clearcoat=`*(self: BaseMaterial3D; value) = self.setClearcoat(value)
@@ -890,35 +890,35 @@ template `clearcoat=`*(self: BaseMaterial3D; value) = self.setClearcoat(value)
 template clearcoatRoughness*(self: BaseMaterial3D): untyped = self.getClearcoatRoughness()
 template `clearcoatRoughness=`*(self: BaseMaterial3D; value) = self.setClearcoatRoughness(value)
 
-template clearcoatTexture*(self: BaseMaterial3D): untyped = self.getTexture(6)
-template `clearcoatTexture=`*(self: BaseMaterial3D; value) = self.setTexture(6, value)
+template clearcoatTexture*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(6))
+template `clearcoatTexture=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(6), value)
 
-template anisotropyEnabled*(self: BaseMaterial3D): untyped = self.getFeature(4)
-template `anisotropyEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(4, value)
+template anisotropyEnabled*(self: BaseMaterial3D): untyped = self.getFeature(BaseMaterial3D_Feature(4))
+template `anisotropyEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(BaseMaterial3D_Feature(4), value)
 
 template anisotropy*(self: BaseMaterial3D): untyped = self.getAnisotropy()
 template `anisotropy=`*(self: BaseMaterial3D; value) = self.setAnisotropy(value)
 
-template anisotropyFlowmap*(self: BaseMaterial3D): untyped = self.getTexture(7)
-template `anisotropyFlowmap=`*(self: BaseMaterial3D; value) = self.setTexture(7, value)
+template anisotropyFlowmap*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(7))
+template `anisotropyFlowmap=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(7), value)
 
-template aoEnabled*(self: BaseMaterial3D): untyped = self.getFeature(5)
-template `aoEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(5, value)
+template aoEnabled*(self: BaseMaterial3D): untyped = self.getFeature(BaseMaterial3D_Feature(5))
+template `aoEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(BaseMaterial3D_Feature(5), value)
 
 template aoLightAffect*(self: BaseMaterial3D): untyped = self.getAoLightAffect()
 template `aoLightAffect=`*(self: BaseMaterial3D; value) = self.setAoLightAffect(value)
 
-template aoTexture*(self: BaseMaterial3D): untyped = self.getTexture(8)
-template `aoTexture=`*(self: BaseMaterial3D; value) = self.setTexture(8, value)
+template aoTexture*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(8))
+template `aoTexture=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(8), value)
 
-template aoOnUv2*(self: BaseMaterial3D): untyped = self.getFlag(10)
-template `aoOnUv2=`*(self: BaseMaterial3D; value) = self.setFlag(10, value)
+template aoOnUv2*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(10))
+template `aoOnUv2=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(10), value)
 
 template aoTextureChannel*(self: BaseMaterial3D): untyped = self.getAoTextureChannel()
 template `aoTextureChannel=`*(self: BaseMaterial3D; value) = self.setAoTextureChannel(value)
 
-template heightmapEnabled*(self: BaseMaterial3D): untyped = self.getFeature(6)
-template `heightmapEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(6, value)
+template heightmapEnabled*(self: BaseMaterial3D): untyped = self.getFeature(BaseMaterial3D_Feature(6))
+template `heightmapEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(BaseMaterial3D_Feature(6), value)
 
 template heightmapScale*(self: BaseMaterial3D): untyped = self.getHeightmapScale()
 template `heightmapScale=`*(self: BaseMaterial3D; value) = self.setHeightmapScale(value)
@@ -938,32 +938,32 @@ template `heightmapFlipTangent=`*(self: BaseMaterial3D; value) = self.setHeightm
 template heightmapFlipBinormal*(self: BaseMaterial3D): untyped = self.getHeightmapDeepParallaxFlipBinormal()
 template `heightmapFlipBinormal=`*(self: BaseMaterial3D; value) = self.setHeightmapDeepParallaxFlipBinormal(value)
 
-template heightmapTexture*(self: BaseMaterial3D): untyped = self.getTexture(9)
-template `heightmapTexture=`*(self: BaseMaterial3D; value) = self.setTexture(9, value)
+template heightmapTexture*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(9))
+template `heightmapTexture=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(9), value)
 
-template heightmapFlipTexture*(self: BaseMaterial3D): untyped = self.getFlag(17)
-template `heightmapFlipTexture=`*(self: BaseMaterial3D; value) = self.setFlag(17, value)
+template heightmapFlipTexture*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(17))
+template `heightmapFlipTexture=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(17), value)
 
-template subsurfScatterEnabled*(self: BaseMaterial3D): untyped = self.getFeature(7)
-template `subsurfScatterEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(7, value)
+template subsurfScatterEnabled*(self: BaseMaterial3D): untyped = self.getFeature(BaseMaterial3D_Feature(7))
+template `subsurfScatterEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(BaseMaterial3D_Feature(7), value)
 
 template subsurfScatterStrength*(self: BaseMaterial3D): untyped = self.getSubsurfaceScatteringStrength()
 template `subsurfScatterStrength=`*(self: BaseMaterial3D; value) = self.setSubsurfaceScatteringStrength(value)
 
-template subsurfScatterSkinMode*(self: BaseMaterial3D): untyped = self.getFlag(18)
-template `subsurfScatterSkinMode=`*(self: BaseMaterial3D; value) = self.setFlag(18, value)
+template subsurfScatterSkinMode*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(18))
+template `subsurfScatterSkinMode=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(18), value)
 
-template subsurfScatterTexture*(self: BaseMaterial3D): untyped = self.getTexture(10)
-template `subsurfScatterTexture=`*(self: BaseMaterial3D; value) = self.setTexture(10, value)
+template subsurfScatterTexture*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(10))
+template `subsurfScatterTexture=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(10), value)
 
-template subsurfScatterTransmittanceEnabled*(self: BaseMaterial3D): untyped = self.getFeature(8)
-template `subsurfScatterTransmittanceEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(8, value)
+template subsurfScatterTransmittanceEnabled*(self: BaseMaterial3D): untyped = self.getFeature(BaseMaterial3D_Feature(8))
+template `subsurfScatterTransmittanceEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(BaseMaterial3D_Feature(8), value)
 
 template subsurfScatterTransmittanceColor*(self: BaseMaterial3D): untyped = self.getTransmittanceColor()
 template `subsurfScatterTransmittanceColor=`*(self: BaseMaterial3D; value) = self.setTransmittanceColor(value)
 
-template subsurfScatterTransmittanceTexture*(self: BaseMaterial3D): untyped = self.getTexture(11)
-template `subsurfScatterTransmittanceTexture=`*(self: BaseMaterial3D; value) = self.setTexture(11, value)
+template subsurfScatterTransmittanceTexture*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(11))
+template `subsurfScatterTransmittanceTexture=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(11), value)
 
 template subsurfScatterTransmittanceDepth*(self: BaseMaterial3D): untyped = self.getTransmittanceDepth()
 template `subsurfScatterTransmittanceDepth=`*(self: BaseMaterial3D; value) = self.setTransmittanceDepth(value)
@@ -971,32 +971,32 @@ template `subsurfScatterTransmittanceDepth=`*(self: BaseMaterial3D; value) = sel
 template subsurfScatterTransmittanceBoost*(self: BaseMaterial3D): untyped = self.getTransmittanceBoost()
 template `subsurfScatterTransmittanceBoost=`*(self: BaseMaterial3D; value) = self.setTransmittanceBoost(value)
 
-template backlightEnabled*(self: BaseMaterial3D): untyped = self.getFeature(9)
-template `backlightEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(9, value)
+template backlightEnabled*(self: BaseMaterial3D): untyped = self.getFeature(BaseMaterial3D_Feature(9))
+template `backlightEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(BaseMaterial3D_Feature(9), value)
 
 template backlight*(self: BaseMaterial3D): untyped = self.getBacklight()
 template `backlight=`*(self: BaseMaterial3D; value) = self.setBacklight(value)
 
-template backlightTexture*(self: BaseMaterial3D): untyped = self.getTexture(12)
-template `backlightTexture=`*(self: BaseMaterial3D; value) = self.setTexture(12, value)
+template backlightTexture*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(12))
+template `backlightTexture=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(12), value)
 
-template refractionEnabled*(self: BaseMaterial3D): untyped = self.getFeature(10)
-template `refractionEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(10, value)
+template refractionEnabled*(self: BaseMaterial3D): untyped = self.getFeature(BaseMaterial3D_Feature(10))
+template `refractionEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(BaseMaterial3D_Feature(10), value)
 
 template refractionScale*(self: BaseMaterial3D): untyped = self.getRefraction()
 template `refractionScale=`*(self: BaseMaterial3D; value) = self.setRefraction(value)
 
-template refractionTexture*(self: BaseMaterial3D): untyped = self.getTexture(13)
-template `refractionTexture=`*(self: BaseMaterial3D; value) = self.setTexture(13, value)
+template refractionTexture*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(13))
+template `refractionTexture=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(13), value)
 
 template refractionTextureChannel*(self: BaseMaterial3D): untyped = self.getRefractionTextureChannel()
 template `refractionTextureChannel=`*(self: BaseMaterial3D; value) = self.setRefractionTextureChannel(value)
 
-template detailEnabled*(self: BaseMaterial3D): untyped = self.getFeature(11)
-template `detailEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(11, value)
+template detailEnabled*(self: BaseMaterial3D): untyped = self.getFeature(BaseMaterial3D_Feature(11))
+template `detailEnabled=`*(self: BaseMaterial3D; value) = self.setFeature(BaseMaterial3D_Feature(11), value)
 
-template detailMask*(self: BaseMaterial3D): untyped = self.getTexture(14)
-template `detailMask=`*(self: BaseMaterial3D; value) = self.setTexture(14, value)
+template detailMask*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(14))
+template `detailMask=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(14), value)
 
 template detailBlendMode*(self: BaseMaterial3D): untyped = self.getDetailBlendMode()
 template `detailBlendMode=`*(self: BaseMaterial3D; value) = self.setDetailBlendMode(value)
@@ -1004,11 +1004,11 @@ template `detailBlendMode=`*(self: BaseMaterial3D; value) = self.setDetailBlendM
 template detailUvLayer*(self: BaseMaterial3D): untyped = self.getDetailUv()
 template `detailUvLayer=`*(self: BaseMaterial3D; value) = self.setDetailUv(value)
 
-template detailAlbedo*(self: BaseMaterial3D): untyped = self.getTexture(15)
-template `detailAlbedo=`*(self: BaseMaterial3D; value) = self.setTexture(15, value)
+template detailAlbedo*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(15))
+template `detailAlbedo=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(15), value)
 
-template detailNormal*(self: BaseMaterial3D): untyped = self.getTexture(16)
-template `detailNormal=`*(self: BaseMaterial3D; value) = self.setTexture(16, value)
+template detailNormal*(self: BaseMaterial3D): untyped = self.getTexture(BaseMaterial3D_TextureParam(16))
+template `detailNormal=`*(self: BaseMaterial3D; value) = self.setTexture(BaseMaterial3D_TextureParam(16), value)
 
 template uv1Scale*(self: BaseMaterial3D): untyped = self.getUv1Scale()
 template `uv1Scale=`*(self: BaseMaterial3D; value) = self.setUv1Scale(value)
@@ -1016,14 +1016,14 @@ template `uv1Scale=`*(self: BaseMaterial3D; value) = self.setUv1Scale(value)
 template uv1Offset*(self: BaseMaterial3D): untyped = self.getUv1Offset()
 template `uv1Offset=`*(self: BaseMaterial3D; value) = self.setUv1Offset(value)
 
-template uv1Triplanar*(self: BaseMaterial3D): untyped = self.getFlag(6)
-template `uv1Triplanar=`*(self: BaseMaterial3D; value) = self.setFlag(6, value)
+template uv1Triplanar*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(6))
+template `uv1Triplanar=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(6), value)
 
 template uv1TriplanarSharpness*(self: BaseMaterial3D): untyped = self.getUv1TriplanarBlendSharpness()
 template `uv1TriplanarSharpness=`*(self: BaseMaterial3D; value) = self.setUv1TriplanarBlendSharpness(value)
 
-template uv1WorldTriplanar*(self: BaseMaterial3D): untyped = self.getFlag(8)
-template `uv1WorldTriplanar=`*(self: BaseMaterial3D; value) = self.setFlag(8, value)
+template uv1WorldTriplanar*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(8))
+template `uv1WorldTriplanar=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(8), value)
 
 template uv2Scale*(self: BaseMaterial3D): untyped = self.getUv2Scale()
 template `uv2Scale=`*(self: BaseMaterial3D; value) = self.setUv2Scale(value)
@@ -1031,32 +1031,32 @@ template `uv2Scale=`*(self: BaseMaterial3D; value) = self.setUv2Scale(value)
 template uv2Offset*(self: BaseMaterial3D): untyped = self.getUv2Offset()
 template `uv2Offset=`*(self: BaseMaterial3D; value) = self.setUv2Offset(value)
 
-template uv2Triplanar*(self: BaseMaterial3D): untyped = self.getFlag(7)
-template `uv2Triplanar=`*(self: BaseMaterial3D; value) = self.setFlag(7, value)
+template uv2Triplanar*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(7))
+template `uv2Triplanar=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(7), value)
 
 template uv2TriplanarSharpness*(self: BaseMaterial3D): untyped = self.getUv2TriplanarBlendSharpness()
 template `uv2TriplanarSharpness=`*(self: BaseMaterial3D; value) = self.setUv2TriplanarBlendSharpness(value)
 
-template uv2WorldTriplanar*(self: BaseMaterial3D): untyped = self.getFlag(9)
-template `uv2WorldTriplanar=`*(self: BaseMaterial3D; value) = self.setFlag(9, value)
+template uv2WorldTriplanar*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(9))
+template `uv2WorldTriplanar=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(9), value)
 
 template textureFilter*(self: BaseMaterial3D): untyped = self.getTextureFilter()
 template `textureFilter=`*(self: BaseMaterial3D; value) = self.setTextureFilter(value)
 
-template textureRepeat*(self: BaseMaterial3D): untyped = self.getFlag(16)
-template `textureRepeat=`*(self: BaseMaterial3D; value) = self.setFlag(16, value)
+template textureRepeat*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(16))
+template `textureRepeat=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(16), value)
 
-template disableReceiveShadows*(self: BaseMaterial3D): untyped = self.getFlag(13)
-template `disableReceiveShadows=`*(self: BaseMaterial3D; value) = self.setFlag(13, value)
+template disableReceiveShadows*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(13))
+template `disableReceiveShadows=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(13), value)
 
-template shadowToOpacity*(self: BaseMaterial3D): untyped = self.getFlag(15)
-template `shadowToOpacity=`*(self: BaseMaterial3D; value) = self.setFlag(15, value)
+template shadowToOpacity*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(15))
+template `shadowToOpacity=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(15), value)
 
 template billboardMode*(self: BaseMaterial3D): untyped = self.getBillboardMode()
 template `billboardMode=`*(self: BaseMaterial3D; value) = self.setBillboardMode(value)
 
-template billboardKeepScale*(self: BaseMaterial3D): untyped = self.getFlag(5)
-template `billboardKeepScale=`*(self: BaseMaterial3D; value) = self.setFlag(5, value)
+template billboardKeepScale*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(5))
+template `billboardKeepScale=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(5), value)
 
 template particlesAnimHFrames*(self: BaseMaterial3D): untyped = self.getParticlesAnimHFrames()
 template `particlesAnimHFrames=`*(self: BaseMaterial3D; value) = self.setParticlesAnimHFrames(value)
@@ -1073,17 +1073,17 @@ template `grow=`*(self: BaseMaterial3D; value) = self.setGrowEnabled(value)
 template growAmount*(self: BaseMaterial3D): untyped = self.getGrow()
 template `growAmount=`*(self: BaseMaterial3D; value) = self.setGrow(value)
 
-template fixedSize*(self: BaseMaterial3D): untyped = self.getFlag(4)
-template `fixedSize=`*(self: BaseMaterial3D; value) = self.setFlag(4, value)
+template fixedSize*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(4))
+template `fixedSize=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(4), value)
 
-template usePointSize*(self: BaseMaterial3D): untyped = self.getFlag(3)
-template `usePointSize=`*(self: BaseMaterial3D; value) = self.setFlag(3, value)
+template usePointSize*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(3))
+template `usePointSize=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(3), value)
 
 template pointSize*(self: BaseMaterial3D): untyped = self.getPointSize()
 template `pointSize=`*(self: BaseMaterial3D; value) = self.setPointSize(value)
 
-template useParticleTrails*(self: BaseMaterial3D): untyped = self.getFlag(19)
-template `useParticleTrails=`*(self: BaseMaterial3D; value) = self.setFlag(19, value)
+template useParticleTrails*(self: BaseMaterial3D): untyped = self.getFlag(BaseMaterial3D_Flags(19))
+template `useParticleTrails=`*(self: BaseMaterial3D; value) = self.setFlag(BaseMaterial3D_Flags(19), value)
 
 template proximityFadeEnabled*(self: BaseMaterial3D): untyped = self.isProximityFadeEnabled()
 template `proximityFadeEnabled=`*(self: BaseMaterial3D; value) = self.setProximityFadeEnabled(value)

--- a/src/gdext/classes/gdcamera2d.nim
+++ b/src/gdext/classes/gdcamera2d.nim
@@ -292,17 +292,17 @@ template `customViewport=`*(self: Camera2D; value) = self.setCustomViewport(valu
 template processCallback*(self: Camera2D): untyped = self.getProcessCallback()
 template `processCallback=`*(self: Camera2D; value) = self.setProcessCallback(value)
 
-template limitLeft*(self: Camera2D): untyped = self.getLimit(0)
-template `limitLeft=`*(self: Camera2D; value) = self.setLimit(0, value)
+template limitLeft*(self: Camera2D): untyped = self.getLimit(Side(0))
+template `limitLeft=`*(self: Camera2D; value) = self.setLimit(Side(0), value)
 
-template limitTop*(self: Camera2D): untyped = self.getLimit(1)
-template `limitTop=`*(self: Camera2D; value) = self.setLimit(1, value)
+template limitTop*(self: Camera2D): untyped = self.getLimit(Side(1))
+template `limitTop=`*(self: Camera2D; value) = self.setLimit(Side(1), value)
 
-template limitRight*(self: Camera2D): untyped = self.getLimit(2)
-template `limitRight=`*(self: Camera2D; value) = self.setLimit(2, value)
+template limitRight*(self: Camera2D): untyped = self.getLimit(Side(2))
+template `limitRight=`*(self: Camera2D; value) = self.setLimit(Side(2), value)
 
-template limitBottom*(self: Camera2D): untyped = self.getLimit(3)
-template `limitBottom=`*(self: Camera2D; value) = self.setLimit(3, value)
+template limitBottom*(self: Camera2D): untyped = self.getLimit(Side(3))
+template `limitBottom=`*(self: Camera2D; value) = self.setLimit(Side(3), value)
 
 template limitSmoothed*(self: Camera2D): untyped = self.isLimitSmoothingEnabled()
 template `limitSmoothed=`*(self: Camera2D; value) = self.setLimitSmoothingEnabled(value)
@@ -331,17 +331,17 @@ template `dragHorizontalOffset=`*(self: Camera2D; value) = self.setDragHorizonta
 template dragVerticalOffset*(self: Camera2D): untyped = self.getDragVerticalOffset()
 template `dragVerticalOffset=`*(self: Camera2D; value) = self.setDragVerticalOffset(value)
 
-template dragLeftMargin*(self: Camera2D): untyped = self.getDragMargin(0)
-template `dragLeftMargin=`*(self: Camera2D; value) = self.setDragMargin(0, value)
+template dragLeftMargin*(self: Camera2D): untyped = self.getDragMargin(Side(0))
+template `dragLeftMargin=`*(self: Camera2D; value) = self.setDragMargin(Side(0), value)
 
-template dragTopMargin*(self: Camera2D): untyped = self.getDragMargin(1)
-template `dragTopMargin=`*(self: Camera2D; value) = self.setDragMargin(1, value)
+template dragTopMargin*(self: Camera2D): untyped = self.getDragMargin(Side(1))
+template `dragTopMargin=`*(self: Camera2D; value) = self.setDragMargin(Side(1), value)
 
-template dragRightMargin*(self: Camera2D): untyped = self.getDragMargin(2)
-template `dragRightMargin=`*(self: Camera2D; value) = self.setDragMargin(2, value)
+template dragRightMargin*(self: Camera2D): untyped = self.getDragMargin(Side(2))
+template `dragRightMargin=`*(self: Camera2D; value) = self.setDragMargin(Side(2), value)
 
-template dragBottomMargin*(self: Camera2D): untyped = self.getDragMargin(3)
-template `dragBottomMargin=`*(self: Camera2D; value) = self.setDragMargin(3, value)
+template dragBottomMargin*(self: Camera2D): untyped = self.getDragMargin(Side(3))
+template `dragBottomMargin=`*(self: Camera2D; value) = self.setDragMargin(Side(3), value)
 
 template editorDrawScreen*(self: Camera2D): untyped = self.isScreenDrawingEnabled()
 template `editorDrawScreen=`*(self: Camera2D; value) = self.setScreenDrawingEnabled(value)

--- a/src/gdext/classes/gdconetwistjoint3d.nim
+++ b/src/gdext/classes/gdconetwistjoint3d.nim
@@ -16,20 +16,20 @@ proc getParam*(self: ConeTwistJoint3D; param: ConeTwistJoint3D_Param): Float =
   methodbind.ptrcall(self, addr `?param`[0], addr ret)
   (addr ret).decode_result(Float)
 
-template swingSpan*(self: ConeTwistJoint3D): untyped = self.getParam(0)
-template `swingSpan=`*(self: ConeTwistJoint3D; value) = self.setParam(0, value)
+template swingSpan*(self: ConeTwistJoint3D): untyped = self.getParam(ConeTwistJoint3D_Param(0))
+template `swingSpan=`*(self: ConeTwistJoint3D; value) = self.setParam(ConeTwistJoint3D_Param(0), value)
 
-template twistSpan*(self: ConeTwistJoint3D): untyped = self.getParam(1)
-template `twistSpan=`*(self: ConeTwistJoint3D; value) = self.setParam(1, value)
+template twistSpan*(self: ConeTwistJoint3D): untyped = self.getParam(ConeTwistJoint3D_Param(1))
+template `twistSpan=`*(self: ConeTwistJoint3D; value) = self.setParam(ConeTwistJoint3D_Param(1), value)
 
-template bias*(self: ConeTwistJoint3D): untyped = self.getParam(2)
-template `bias=`*(self: ConeTwistJoint3D; value) = self.setParam(2, value)
+template bias*(self: ConeTwistJoint3D): untyped = self.getParam(ConeTwistJoint3D_Param(2))
+template `bias=`*(self: ConeTwistJoint3D; value) = self.setParam(ConeTwistJoint3D_Param(2), value)
 
-template softness*(self: ConeTwistJoint3D): untyped = self.getParam(3)
-template `softness=`*(self: ConeTwistJoint3D; value) = self.setParam(3, value)
+template softness*(self: ConeTwistJoint3D): untyped = self.getParam(ConeTwistJoint3D_Param(3))
+template `softness=`*(self: ConeTwistJoint3D; value) = self.setParam(ConeTwistJoint3D_Param(3), value)
 
-template relaxation*(self: ConeTwistJoint3D): untyped = self.getParam(4)
-template `relaxation=`*(self: ConeTwistJoint3D; value) = self.setParam(4, value)
+template relaxation*(self: ConeTwistJoint3D): untyped = self.getParam(ConeTwistJoint3D_Param(4))
+template `relaxation=`*(self: ConeTwistJoint3D; value) = self.setParam(ConeTwistJoint3D_Param(4), value)
 
 const ConeTwistJoint3D_vmap =
   Joint3D.vmap.concat initTable[string, string]()

--- a/src/gdext/classes/gdcontrol.nim
+++ b/src/gdext/classes/gdcontrol.nim
@@ -788,29 +788,29 @@ template `layoutMode=`*(self: Control; value) = self.setLayoutMode(value)
 template anchorsPreset*(self: Control): untyped = self.getAnchorsLayoutPreset()
 template `anchorsPreset=`*(self: Control; value) = self.setAnchorsLayoutPreset(value)
 
-template anchorLeft*(self: Control): untyped = self.getAnchor(0)
-template `anchorLeft=`*(self: Control; value) = self.setAnchor(0, value)
+template anchorLeft*(self: Control): untyped = self.getAnchor(Side(0))
+template `anchorLeft=`*(self: Control; value) = self.setAnchor(Side(0), value)
 
-template anchorTop*(self: Control): untyped = self.getAnchor(1)
-template `anchorTop=`*(self: Control; value) = self.setAnchor(1, value)
+template anchorTop*(self: Control): untyped = self.getAnchor(Side(1))
+template `anchorTop=`*(self: Control; value) = self.setAnchor(Side(1), value)
 
-template anchorRight*(self: Control): untyped = self.getAnchor(2)
-template `anchorRight=`*(self: Control; value) = self.setAnchor(2, value)
+template anchorRight*(self: Control): untyped = self.getAnchor(Side(2))
+template `anchorRight=`*(self: Control; value) = self.setAnchor(Side(2), value)
 
-template anchorBottom*(self: Control): untyped = self.getAnchor(3)
-template `anchorBottom=`*(self: Control; value) = self.setAnchor(3, value)
+template anchorBottom*(self: Control): untyped = self.getAnchor(Side(3))
+template `anchorBottom=`*(self: Control; value) = self.setAnchor(Side(3), value)
 
-template offsetLeft*(self: Control): untyped = self.getOffset(0)
-template `offsetLeft=`*(self: Control; value) = self.setOffset(0, value)
+template offsetLeft*(self: Control): untyped = self.getOffset(Side(0))
+template `offsetLeft=`*(self: Control; value) = self.setOffset(Side(0), value)
 
-template offsetTop*(self: Control): untyped = self.getOffset(1)
-template `offsetTop=`*(self: Control; value) = self.setOffset(1, value)
+template offsetTop*(self: Control): untyped = self.getOffset(Side(1))
+template `offsetTop=`*(self: Control; value) = self.setOffset(Side(1), value)
 
-template offsetRight*(self: Control): untyped = self.getOffset(2)
-template `offsetRight=`*(self: Control; value) = self.setOffset(2, value)
+template offsetRight*(self: Control): untyped = self.getOffset(Side(2))
+template `offsetRight=`*(self: Control; value) = self.setOffset(Side(2), value)
 
-template offsetBottom*(self: Control): untyped = self.getOffset(3)
-template `offsetBottom=`*(self: Control; value) = self.setOffset(3, value)
+template offsetBottom*(self: Control): untyped = self.getOffset(Side(3))
+template `offsetBottom=`*(self: Control; value) = self.setOffset(Side(3), value)
 
 template growHorizontal*(self: Control): untyped = self.getHGrowDirection()
 template `growHorizontal=`*(self: Control; value) = self.setHGrowDirection(value)
@@ -857,17 +857,17 @@ template `autoTranslate=`*(self: Control; value) = self.setAutoTranslate(value)
 template tooltipText*(self: Control): untyped = self.getTooltipText()
 template `tooltipText=`*(self: Control; value) = self.setTooltipText(value)
 
-template focusNeighborLeft*(self: Control): untyped = self.getFocusNeighbor(0)
-template `focusNeighborLeft=`*(self: Control; value) = self.setFocusNeighbor(0, value)
+template focusNeighborLeft*(self: Control): untyped = self.getFocusNeighbor(Side(0))
+template `focusNeighborLeft=`*(self: Control; value) = self.setFocusNeighbor(Side(0), value)
 
-template focusNeighborTop*(self: Control): untyped = self.getFocusNeighbor(1)
-template `focusNeighborTop=`*(self: Control; value) = self.setFocusNeighbor(1, value)
+template focusNeighborTop*(self: Control): untyped = self.getFocusNeighbor(Side(1))
+template `focusNeighborTop=`*(self: Control; value) = self.setFocusNeighbor(Side(1), value)
 
-template focusNeighborRight*(self: Control): untyped = self.getFocusNeighbor(2)
-template `focusNeighborRight=`*(self: Control; value) = self.setFocusNeighbor(2, value)
+template focusNeighborRight*(self: Control): untyped = self.getFocusNeighbor(Side(2))
+template `focusNeighborRight=`*(self: Control; value) = self.setFocusNeighbor(Side(2), value)
 
-template focusNeighborBottom*(self: Control): untyped = self.getFocusNeighbor(3)
-template `focusNeighborBottom=`*(self: Control; value) = self.setFocusNeighbor(3, value)
+template focusNeighborBottom*(self: Control): untyped = self.getFocusNeighbor(Side(3))
+template `focusNeighborBottom=`*(self: Control; value) = self.setFocusNeighbor(Side(3), value)
 
 template focusNext*(self: Control): untyped = self.getFocusNext()
 template `focusNext=`*(self: Control; value) = self.setFocusNext(value)

--- a/src/gdext/classes/gdcpuparticles2d.nim
+++ b/src/gdext/classes/gdcpuparticles2d.nim
@@ -440,8 +440,8 @@ template `emissionNormals=`*(self: CpuParticles2D; value) = self.setEmissionNorm
 template emissionColors*(self: CpuParticles2D): untyped = self.getEmissionColors()
 template `emissionColors=`*(self: CpuParticles2D; value) = self.setEmissionColors(value)
 
-template particleFlagAlignY*(self: CpuParticles2D): untyped = self.getParticleFlag(0)
-template `particleFlagAlignY=`*(self: CpuParticles2D; value) = self.setParticleFlag(0, value)
+template particleFlagAlignY*(self: CpuParticles2D): untyped = self.getParticleFlag(CpuParticles2D_ParticleFlags(0))
+template `particleFlagAlignY=`*(self: CpuParticles2D; value) = self.setParticleFlag(CpuParticles2D_ParticleFlags(0), value)
 
 template direction*(self: CpuParticles2D): untyped = self.getDirection()
 template `direction=`*(self: CpuParticles2D; value) = self.setDirection(value)
@@ -452,83 +452,83 @@ template `spread=`*(self: CpuParticles2D; value) = self.setSpread(value)
 template gravity*(self: CpuParticles2D): untyped = self.getGravity()
 template `gravity=`*(self: CpuParticles2D; value) = self.setGravity(value)
 
-template initialVelocityMin*(self: CpuParticles2D): untyped = self.getParamMin(0)
-template `initialVelocityMin=`*(self: CpuParticles2D; value) = self.setParamMin(0, value)
+template initialVelocityMin*(self: CpuParticles2D): untyped = self.getParamMin(CpuParticles2D_Parameter(0))
+template `initialVelocityMin=`*(self: CpuParticles2D; value) = self.setParamMin(CpuParticles2D_Parameter(0), value)
 
-template initialVelocityMax*(self: CpuParticles2D): untyped = self.getParamMax(0)
-template `initialVelocityMax=`*(self: CpuParticles2D; value) = self.setParamMax(0, value)
+template initialVelocityMax*(self: CpuParticles2D): untyped = self.getParamMax(CpuParticles2D_Parameter(0))
+template `initialVelocityMax=`*(self: CpuParticles2D; value) = self.setParamMax(CpuParticles2D_Parameter(0), value)
 
-template angularVelocityMin*(self: CpuParticles2D): untyped = self.getParamMin(1)
-template `angularVelocityMin=`*(self: CpuParticles2D; value) = self.setParamMin(1, value)
+template angularVelocityMin*(self: CpuParticles2D): untyped = self.getParamMin(CpuParticles2D_Parameter(1))
+template `angularVelocityMin=`*(self: CpuParticles2D; value) = self.setParamMin(CpuParticles2D_Parameter(1), value)
 
-template angularVelocityMax*(self: CpuParticles2D): untyped = self.getParamMax(1)
-template `angularVelocityMax=`*(self: CpuParticles2D; value) = self.setParamMax(1, value)
+template angularVelocityMax*(self: CpuParticles2D): untyped = self.getParamMax(CpuParticles2D_Parameter(1))
+template `angularVelocityMax=`*(self: CpuParticles2D; value) = self.setParamMax(CpuParticles2D_Parameter(1), value)
 
-template angularVelocityCurve*(self: CpuParticles2D): untyped = self.getParamCurve(1)
-template `angularVelocityCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(1, value)
+template angularVelocityCurve*(self: CpuParticles2D): untyped = self.getParamCurve(CpuParticles2D_Parameter(1))
+template `angularVelocityCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(CpuParticles2D_Parameter(1), value)
 
-template orbitVelocityMin*(self: CpuParticles2D): untyped = self.getParamMin(2)
-template `orbitVelocityMin=`*(self: CpuParticles2D; value) = self.setParamMin(2, value)
+template orbitVelocityMin*(self: CpuParticles2D): untyped = self.getParamMin(CpuParticles2D_Parameter(2))
+template `orbitVelocityMin=`*(self: CpuParticles2D; value) = self.setParamMin(CpuParticles2D_Parameter(2), value)
 
-template orbitVelocityMax*(self: CpuParticles2D): untyped = self.getParamMax(2)
-template `orbitVelocityMax=`*(self: CpuParticles2D; value) = self.setParamMax(2, value)
+template orbitVelocityMax*(self: CpuParticles2D): untyped = self.getParamMax(CpuParticles2D_Parameter(2))
+template `orbitVelocityMax=`*(self: CpuParticles2D; value) = self.setParamMax(CpuParticles2D_Parameter(2), value)
 
-template orbitVelocityCurve*(self: CpuParticles2D): untyped = self.getParamCurve(2)
-template `orbitVelocityCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(2, value)
+template orbitVelocityCurve*(self: CpuParticles2D): untyped = self.getParamCurve(CpuParticles2D_Parameter(2))
+template `orbitVelocityCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(CpuParticles2D_Parameter(2), value)
 
-template linearAccelMin*(self: CpuParticles2D): untyped = self.getParamMin(3)
-template `linearAccelMin=`*(self: CpuParticles2D; value) = self.setParamMin(3, value)
+template linearAccelMin*(self: CpuParticles2D): untyped = self.getParamMin(CpuParticles2D_Parameter(3))
+template `linearAccelMin=`*(self: CpuParticles2D; value) = self.setParamMin(CpuParticles2D_Parameter(3), value)
 
-template linearAccelMax*(self: CpuParticles2D): untyped = self.getParamMax(3)
-template `linearAccelMax=`*(self: CpuParticles2D; value) = self.setParamMax(3, value)
+template linearAccelMax*(self: CpuParticles2D): untyped = self.getParamMax(CpuParticles2D_Parameter(3))
+template `linearAccelMax=`*(self: CpuParticles2D; value) = self.setParamMax(CpuParticles2D_Parameter(3), value)
 
-template linearAccelCurve*(self: CpuParticles2D): untyped = self.getParamCurve(3)
-template `linearAccelCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(3, value)
+template linearAccelCurve*(self: CpuParticles2D): untyped = self.getParamCurve(CpuParticles2D_Parameter(3))
+template `linearAccelCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(CpuParticles2D_Parameter(3), value)
 
-template radialAccelMin*(self: CpuParticles2D): untyped = self.getParamMin(4)
-template `radialAccelMin=`*(self: CpuParticles2D; value) = self.setParamMin(4, value)
+template radialAccelMin*(self: CpuParticles2D): untyped = self.getParamMin(CpuParticles2D_Parameter(4))
+template `radialAccelMin=`*(self: CpuParticles2D; value) = self.setParamMin(CpuParticles2D_Parameter(4), value)
 
-template radialAccelMax*(self: CpuParticles2D): untyped = self.getParamMax(4)
-template `radialAccelMax=`*(self: CpuParticles2D; value) = self.setParamMax(4, value)
+template radialAccelMax*(self: CpuParticles2D): untyped = self.getParamMax(CpuParticles2D_Parameter(4))
+template `radialAccelMax=`*(self: CpuParticles2D; value) = self.setParamMax(CpuParticles2D_Parameter(4), value)
 
-template radialAccelCurve*(self: CpuParticles2D): untyped = self.getParamCurve(4)
-template `radialAccelCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(4, value)
+template radialAccelCurve*(self: CpuParticles2D): untyped = self.getParamCurve(CpuParticles2D_Parameter(4))
+template `radialAccelCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(CpuParticles2D_Parameter(4), value)
 
-template tangentialAccelMin*(self: CpuParticles2D): untyped = self.getParamMin(5)
-template `tangentialAccelMin=`*(self: CpuParticles2D; value) = self.setParamMin(5, value)
+template tangentialAccelMin*(self: CpuParticles2D): untyped = self.getParamMin(CpuParticles2D_Parameter(5))
+template `tangentialAccelMin=`*(self: CpuParticles2D; value) = self.setParamMin(CpuParticles2D_Parameter(5), value)
 
-template tangentialAccelMax*(self: CpuParticles2D): untyped = self.getParamMax(5)
-template `tangentialAccelMax=`*(self: CpuParticles2D; value) = self.setParamMax(5, value)
+template tangentialAccelMax*(self: CpuParticles2D): untyped = self.getParamMax(CpuParticles2D_Parameter(5))
+template `tangentialAccelMax=`*(self: CpuParticles2D; value) = self.setParamMax(CpuParticles2D_Parameter(5), value)
 
-template tangentialAccelCurve*(self: CpuParticles2D): untyped = self.getParamCurve(5)
-template `tangentialAccelCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(5, value)
+template tangentialAccelCurve*(self: CpuParticles2D): untyped = self.getParamCurve(CpuParticles2D_Parameter(5))
+template `tangentialAccelCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(CpuParticles2D_Parameter(5), value)
 
-template dampingMin*(self: CpuParticles2D): untyped = self.getParamMin(6)
-template `dampingMin=`*(self: CpuParticles2D; value) = self.setParamMin(6, value)
+template dampingMin*(self: CpuParticles2D): untyped = self.getParamMin(CpuParticles2D_Parameter(6))
+template `dampingMin=`*(self: CpuParticles2D; value) = self.setParamMin(CpuParticles2D_Parameter(6), value)
 
-template dampingMax*(self: CpuParticles2D): untyped = self.getParamMax(6)
-template `dampingMax=`*(self: CpuParticles2D; value) = self.setParamMax(6, value)
+template dampingMax*(self: CpuParticles2D): untyped = self.getParamMax(CpuParticles2D_Parameter(6))
+template `dampingMax=`*(self: CpuParticles2D; value) = self.setParamMax(CpuParticles2D_Parameter(6), value)
 
-template dampingCurve*(self: CpuParticles2D): untyped = self.getParamCurve(6)
-template `dampingCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(6, value)
+template dampingCurve*(self: CpuParticles2D): untyped = self.getParamCurve(CpuParticles2D_Parameter(6))
+template `dampingCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(CpuParticles2D_Parameter(6), value)
 
-template angleMin*(self: CpuParticles2D): untyped = self.getParamMin(7)
-template `angleMin=`*(self: CpuParticles2D; value) = self.setParamMin(7, value)
+template angleMin*(self: CpuParticles2D): untyped = self.getParamMin(CpuParticles2D_Parameter(7))
+template `angleMin=`*(self: CpuParticles2D; value) = self.setParamMin(CpuParticles2D_Parameter(7), value)
 
-template angleMax*(self: CpuParticles2D): untyped = self.getParamMax(7)
-template `angleMax=`*(self: CpuParticles2D; value) = self.setParamMax(7, value)
+template angleMax*(self: CpuParticles2D): untyped = self.getParamMax(CpuParticles2D_Parameter(7))
+template `angleMax=`*(self: CpuParticles2D; value) = self.setParamMax(CpuParticles2D_Parameter(7), value)
 
-template angleCurve*(self: CpuParticles2D): untyped = self.getParamCurve(7)
-template `angleCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(7, value)
+template angleCurve*(self: CpuParticles2D): untyped = self.getParamCurve(CpuParticles2D_Parameter(7))
+template `angleCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(CpuParticles2D_Parameter(7), value)
 
-template scaleAmountMin*(self: CpuParticles2D): untyped = self.getParamMin(8)
-template `scaleAmountMin=`*(self: CpuParticles2D; value) = self.setParamMin(8, value)
+template scaleAmountMin*(self: CpuParticles2D): untyped = self.getParamMin(CpuParticles2D_Parameter(8))
+template `scaleAmountMin=`*(self: CpuParticles2D; value) = self.setParamMin(CpuParticles2D_Parameter(8), value)
 
-template scaleAmountMax*(self: CpuParticles2D): untyped = self.getParamMax(8)
-template `scaleAmountMax=`*(self: CpuParticles2D; value) = self.setParamMax(8, value)
+template scaleAmountMax*(self: CpuParticles2D): untyped = self.getParamMax(CpuParticles2D_Parameter(8))
+template `scaleAmountMax=`*(self: CpuParticles2D; value) = self.setParamMax(CpuParticles2D_Parameter(8), value)
 
-template scaleAmountCurve*(self: CpuParticles2D): untyped = self.getParamCurve(8)
-template `scaleAmountCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(8, value)
+template scaleAmountCurve*(self: CpuParticles2D): untyped = self.getParamCurve(CpuParticles2D_Parameter(8))
+template `scaleAmountCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(CpuParticles2D_Parameter(8), value)
 
 template splitScale*(self: CpuParticles2D): untyped = self.getSplitScale()
 template `splitScale=`*(self: CpuParticles2D; value) = self.setSplitScale(value)
@@ -548,32 +548,32 @@ template `colorRamp=`*(self: CpuParticles2D; value) = self.setColorRamp(value)
 template colorInitialRamp*(self: CpuParticles2D): untyped = self.getColorInitialRamp()
 template `colorInitialRamp=`*(self: CpuParticles2D; value) = self.setColorInitialRamp(value)
 
-template hueVariationMin*(self: CpuParticles2D): untyped = self.getParamMin(9)
-template `hueVariationMin=`*(self: CpuParticles2D; value) = self.setParamMin(9, value)
+template hueVariationMin*(self: CpuParticles2D): untyped = self.getParamMin(CpuParticles2D_Parameter(9))
+template `hueVariationMin=`*(self: CpuParticles2D; value) = self.setParamMin(CpuParticles2D_Parameter(9), value)
 
-template hueVariationMax*(self: CpuParticles2D): untyped = self.getParamMax(9)
-template `hueVariationMax=`*(self: CpuParticles2D; value) = self.setParamMax(9, value)
+template hueVariationMax*(self: CpuParticles2D): untyped = self.getParamMax(CpuParticles2D_Parameter(9))
+template `hueVariationMax=`*(self: CpuParticles2D; value) = self.setParamMax(CpuParticles2D_Parameter(9), value)
 
-template hueVariationCurve*(self: CpuParticles2D): untyped = self.getParamCurve(9)
-template `hueVariationCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(9, value)
+template hueVariationCurve*(self: CpuParticles2D): untyped = self.getParamCurve(CpuParticles2D_Parameter(9))
+template `hueVariationCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(CpuParticles2D_Parameter(9), value)
 
-template animSpeedMin*(self: CpuParticles2D): untyped = self.getParamMin(10)
-template `animSpeedMin=`*(self: CpuParticles2D; value) = self.setParamMin(10, value)
+template animSpeedMin*(self: CpuParticles2D): untyped = self.getParamMin(CpuParticles2D_Parameter(10))
+template `animSpeedMin=`*(self: CpuParticles2D; value) = self.setParamMin(CpuParticles2D_Parameter(10), value)
 
-template animSpeedMax*(self: CpuParticles2D): untyped = self.getParamMax(10)
-template `animSpeedMax=`*(self: CpuParticles2D; value) = self.setParamMax(10, value)
+template animSpeedMax*(self: CpuParticles2D): untyped = self.getParamMax(CpuParticles2D_Parameter(10))
+template `animSpeedMax=`*(self: CpuParticles2D; value) = self.setParamMax(CpuParticles2D_Parameter(10), value)
 
-template animSpeedCurve*(self: CpuParticles2D): untyped = self.getParamCurve(10)
-template `animSpeedCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(10, value)
+template animSpeedCurve*(self: CpuParticles2D): untyped = self.getParamCurve(CpuParticles2D_Parameter(10))
+template `animSpeedCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(CpuParticles2D_Parameter(10), value)
 
-template animOffsetMin*(self: CpuParticles2D): untyped = self.getParamMin(11)
-template `animOffsetMin=`*(self: CpuParticles2D; value) = self.setParamMin(11, value)
+template animOffsetMin*(self: CpuParticles2D): untyped = self.getParamMin(CpuParticles2D_Parameter(11))
+template `animOffsetMin=`*(self: CpuParticles2D; value) = self.setParamMin(CpuParticles2D_Parameter(11), value)
 
-template animOffsetMax*(self: CpuParticles2D): untyped = self.getParamMax(11)
-template `animOffsetMax=`*(self: CpuParticles2D; value) = self.setParamMax(11, value)
+template animOffsetMax*(self: CpuParticles2D): untyped = self.getParamMax(CpuParticles2D_Parameter(11))
+template `animOffsetMax=`*(self: CpuParticles2D; value) = self.setParamMax(CpuParticles2D_Parameter(11), value)
 
-template animOffsetCurve*(self: CpuParticles2D): untyped = self.getParamCurve(11)
-template `animOffsetCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(11, value)
+template animOffsetCurve*(self: CpuParticles2D): untyped = self.getParamCurve(CpuParticles2D_Parameter(11))
+template `animOffsetCurve=`*(self: CpuParticles2D; value) = self.setParamCurve(CpuParticles2D_Parameter(11), value)
 
 const CpuParticles2D_vmap =
   Node2D.vmap.concat initTable[string, string]()

--- a/src/gdext/classes/gdcpuparticles3d.nim
+++ b/src/gdext/classes/gdcpuparticles3d.nim
@@ -532,14 +532,14 @@ template `emissionRingRadius=`*(self: CpuParticles3D; value) = self.setEmissionR
 template emissionRingInnerRadius*(self: CpuParticles3D): untyped = self.getEmissionRingInnerRadius()
 template `emissionRingInnerRadius=`*(self: CpuParticles3D; value) = self.setEmissionRingInnerRadius(value)
 
-template particleFlagAlignY*(self: CpuParticles3D): untyped = self.getParticleFlag(0)
-template `particleFlagAlignY=`*(self: CpuParticles3D; value) = self.setParticleFlag(0, value)
+template particleFlagAlignY*(self: CpuParticles3D): untyped = self.getParticleFlag(CpuParticles3D_ParticleFlags(0))
+template `particleFlagAlignY=`*(self: CpuParticles3D; value) = self.setParticleFlag(CpuParticles3D_ParticleFlags(0), value)
 
-template particleFlagRotateY*(self: CpuParticles3D): untyped = self.getParticleFlag(1)
-template `particleFlagRotateY=`*(self: CpuParticles3D; value) = self.setParticleFlag(1, value)
+template particleFlagRotateY*(self: CpuParticles3D): untyped = self.getParticleFlag(CpuParticles3D_ParticleFlags(1))
+template `particleFlagRotateY=`*(self: CpuParticles3D; value) = self.setParticleFlag(CpuParticles3D_ParticleFlags(1), value)
 
-template particleFlagDisableZ*(self: CpuParticles3D): untyped = self.getParticleFlag(2)
-template `particleFlagDisableZ=`*(self: CpuParticles3D; value) = self.setParticleFlag(2, value)
+template particleFlagDisableZ*(self: CpuParticles3D): untyped = self.getParticleFlag(CpuParticles3D_ParticleFlags(2))
+template `particleFlagDisableZ=`*(self: CpuParticles3D; value) = self.setParticleFlag(CpuParticles3D_ParticleFlags(2), value)
 
 template direction*(self: CpuParticles3D): untyped = self.getDirection()
 template `direction=`*(self: CpuParticles3D; value) = self.setDirection(value)
@@ -553,83 +553,83 @@ template `flatness=`*(self: CpuParticles3D; value) = self.setFlatness(value)
 template gravity*(self: CpuParticles3D): untyped = self.getGravity()
 template `gravity=`*(self: CpuParticles3D; value) = self.setGravity(value)
 
-template initialVelocityMin*(self: CpuParticles3D): untyped = self.getParamMin(0)
-template `initialVelocityMin=`*(self: CpuParticles3D; value) = self.setParamMin(0, value)
+template initialVelocityMin*(self: CpuParticles3D): untyped = self.getParamMin(CpuParticles3D_Parameter(0))
+template `initialVelocityMin=`*(self: CpuParticles3D; value) = self.setParamMin(CpuParticles3D_Parameter(0), value)
 
-template initialVelocityMax*(self: CpuParticles3D): untyped = self.getParamMax(0)
-template `initialVelocityMax=`*(self: CpuParticles3D; value) = self.setParamMax(0, value)
+template initialVelocityMax*(self: CpuParticles3D): untyped = self.getParamMax(CpuParticles3D_Parameter(0))
+template `initialVelocityMax=`*(self: CpuParticles3D; value) = self.setParamMax(CpuParticles3D_Parameter(0), value)
 
-template angularVelocityMin*(self: CpuParticles3D): untyped = self.getParamMin(1)
-template `angularVelocityMin=`*(self: CpuParticles3D; value) = self.setParamMin(1, value)
+template angularVelocityMin*(self: CpuParticles3D): untyped = self.getParamMin(CpuParticles3D_Parameter(1))
+template `angularVelocityMin=`*(self: CpuParticles3D; value) = self.setParamMin(CpuParticles3D_Parameter(1), value)
 
-template angularVelocityMax*(self: CpuParticles3D): untyped = self.getParamMax(1)
-template `angularVelocityMax=`*(self: CpuParticles3D; value) = self.setParamMax(1, value)
+template angularVelocityMax*(self: CpuParticles3D): untyped = self.getParamMax(CpuParticles3D_Parameter(1))
+template `angularVelocityMax=`*(self: CpuParticles3D; value) = self.setParamMax(CpuParticles3D_Parameter(1), value)
 
-template angularVelocityCurve*(self: CpuParticles3D): untyped = self.getParamCurve(1)
-template `angularVelocityCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(1, value)
+template angularVelocityCurve*(self: CpuParticles3D): untyped = self.getParamCurve(CpuParticles3D_Parameter(1))
+template `angularVelocityCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(CpuParticles3D_Parameter(1), value)
 
-template orbitVelocityMin*(self: CpuParticles3D): untyped = self.getParamMin(2)
-template `orbitVelocityMin=`*(self: CpuParticles3D; value) = self.setParamMin(2, value)
+template orbitVelocityMin*(self: CpuParticles3D): untyped = self.getParamMin(CpuParticles3D_Parameter(2))
+template `orbitVelocityMin=`*(self: CpuParticles3D; value) = self.setParamMin(CpuParticles3D_Parameter(2), value)
 
-template orbitVelocityMax*(self: CpuParticles3D): untyped = self.getParamMax(2)
-template `orbitVelocityMax=`*(self: CpuParticles3D; value) = self.setParamMax(2, value)
+template orbitVelocityMax*(self: CpuParticles3D): untyped = self.getParamMax(CpuParticles3D_Parameter(2))
+template `orbitVelocityMax=`*(self: CpuParticles3D; value) = self.setParamMax(CpuParticles3D_Parameter(2), value)
 
-template orbitVelocityCurve*(self: CpuParticles3D): untyped = self.getParamCurve(2)
-template `orbitVelocityCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(2, value)
+template orbitVelocityCurve*(self: CpuParticles3D): untyped = self.getParamCurve(CpuParticles3D_Parameter(2))
+template `orbitVelocityCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(CpuParticles3D_Parameter(2), value)
 
-template linearAccelMin*(self: CpuParticles3D): untyped = self.getParamMin(3)
-template `linearAccelMin=`*(self: CpuParticles3D; value) = self.setParamMin(3, value)
+template linearAccelMin*(self: CpuParticles3D): untyped = self.getParamMin(CpuParticles3D_Parameter(3))
+template `linearAccelMin=`*(self: CpuParticles3D; value) = self.setParamMin(CpuParticles3D_Parameter(3), value)
 
-template linearAccelMax*(self: CpuParticles3D): untyped = self.getParamMax(3)
-template `linearAccelMax=`*(self: CpuParticles3D; value) = self.setParamMax(3, value)
+template linearAccelMax*(self: CpuParticles3D): untyped = self.getParamMax(CpuParticles3D_Parameter(3))
+template `linearAccelMax=`*(self: CpuParticles3D; value) = self.setParamMax(CpuParticles3D_Parameter(3), value)
 
-template linearAccelCurve*(self: CpuParticles3D): untyped = self.getParamCurve(3)
-template `linearAccelCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(3, value)
+template linearAccelCurve*(self: CpuParticles3D): untyped = self.getParamCurve(CpuParticles3D_Parameter(3))
+template `linearAccelCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(CpuParticles3D_Parameter(3), value)
 
-template radialAccelMin*(self: CpuParticles3D): untyped = self.getParamMin(4)
-template `radialAccelMin=`*(self: CpuParticles3D; value) = self.setParamMin(4, value)
+template radialAccelMin*(self: CpuParticles3D): untyped = self.getParamMin(CpuParticles3D_Parameter(4))
+template `radialAccelMin=`*(self: CpuParticles3D; value) = self.setParamMin(CpuParticles3D_Parameter(4), value)
 
-template radialAccelMax*(self: CpuParticles3D): untyped = self.getParamMax(4)
-template `radialAccelMax=`*(self: CpuParticles3D; value) = self.setParamMax(4, value)
+template radialAccelMax*(self: CpuParticles3D): untyped = self.getParamMax(CpuParticles3D_Parameter(4))
+template `radialAccelMax=`*(self: CpuParticles3D; value) = self.setParamMax(CpuParticles3D_Parameter(4), value)
 
-template radialAccelCurve*(self: CpuParticles3D): untyped = self.getParamCurve(4)
-template `radialAccelCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(4, value)
+template radialAccelCurve*(self: CpuParticles3D): untyped = self.getParamCurve(CpuParticles3D_Parameter(4))
+template `radialAccelCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(CpuParticles3D_Parameter(4), value)
 
-template tangentialAccelMin*(self: CpuParticles3D): untyped = self.getParamMin(5)
-template `tangentialAccelMin=`*(self: CpuParticles3D; value) = self.setParamMin(5, value)
+template tangentialAccelMin*(self: CpuParticles3D): untyped = self.getParamMin(CpuParticles3D_Parameter(5))
+template `tangentialAccelMin=`*(self: CpuParticles3D; value) = self.setParamMin(CpuParticles3D_Parameter(5), value)
 
-template tangentialAccelMax*(self: CpuParticles3D): untyped = self.getParamMax(5)
-template `tangentialAccelMax=`*(self: CpuParticles3D; value) = self.setParamMax(5, value)
+template tangentialAccelMax*(self: CpuParticles3D): untyped = self.getParamMax(CpuParticles3D_Parameter(5))
+template `tangentialAccelMax=`*(self: CpuParticles3D; value) = self.setParamMax(CpuParticles3D_Parameter(5), value)
 
-template tangentialAccelCurve*(self: CpuParticles3D): untyped = self.getParamCurve(5)
-template `tangentialAccelCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(5, value)
+template tangentialAccelCurve*(self: CpuParticles3D): untyped = self.getParamCurve(CpuParticles3D_Parameter(5))
+template `tangentialAccelCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(CpuParticles3D_Parameter(5), value)
 
-template dampingMin*(self: CpuParticles3D): untyped = self.getParamMin(6)
-template `dampingMin=`*(self: CpuParticles3D; value) = self.setParamMin(6, value)
+template dampingMin*(self: CpuParticles3D): untyped = self.getParamMin(CpuParticles3D_Parameter(6))
+template `dampingMin=`*(self: CpuParticles3D; value) = self.setParamMin(CpuParticles3D_Parameter(6), value)
 
-template dampingMax*(self: CpuParticles3D): untyped = self.getParamMax(6)
-template `dampingMax=`*(self: CpuParticles3D; value) = self.setParamMax(6, value)
+template dampingMax*(self: CpuParticles3D): untyped = self.getParamMax(CpuParticles3D_Parameter(6))
+template `dampingMax=`*(self: CpuParticles3D; value) = self.setParamMax(CpuParticles3D_Parameter(6), value)
 
-template dampingCurve*(self: CpuParticles3D): untyped = self.getParamCurve(6)
-template `dampingCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(6, value)
+template dampingCurve*(self: CpuParticles3D): untyped = self.getParamCurve(CpuParticles3D_Parameter(6))
+template `dampingCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(CpuParticles3D_Parameter(6), value)
 
-template angleMin*(self: CpuParticles3D): untyped = self.getParamMin(7)
-template `angleMin=`*(self: CpuParticles3D; value) = self.setParamMin(7, value)
+template angleMin*(self: CpuParticles3D): untyped = self.getParamMin(CpuParticles3D_Parameter(7))
+template `angleMin=`*(self: CpuParticles3D; value) = self.setParamMin(CpuParticles3D_Parameter(7), value)
 
-template angleMax*(self: CpuParticles3D): untyped = self.getParamMax(7)
-template `angleMax=`*(self: CpuParticles3D; value) = self.setParamMax(7, value)
+template angleMax*(self: CpuParticles3D): untyped = self.getParamMax(CpuParticles3D_Parameter(7))
+template `angleMax=`*(self: CpuParticles3D; value) = self.setParamMax(CpuParticles3D_Parameter(7), value)
 
-template angleCurve*(self: CpuParticles3D): untyped = self.getParamCurve(7)
-template `angleCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(7, value)
+template angleCurve*(self: CpuParticles3D): untyped = self.getParamCurve(CpuParticles3D_Parameter(7))
+template `angleCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(CpuParticles3D_Parameter(7), value)
 
-template scaleAmountMin*(self: CpuParticles3D): untyped = self.getParamMin(8)
-template `scaleAmountMin=`*(self: CpuParticles3D; value) = self.setParamMin(8, value)
+template scaleAmountMin*(self: CpuParticles3D): untyped = self.getParamMin(CpuParticles3D_Parameter(8))
+template `scaleAmountMin=`*(self: CpuParticles3D; value) = self.setParamMin(CpuParticles3D_Parameter(8), value)
 
-template scaleAmountMax*(self: CpuParticles3D): untyped = self.getParamMax(8)
-template `scaleAmountMax=`*(self: CpuParticles3D; value) = self.setParamMax(8, value)
+template scaleAmountMax*(self: CpuParticles3D): untyped = self.getParamMax(CpuParticles3D_Parameter(8))
+template `scaleAmountMax=`*(self: CpuParticles3D; value) = self.setParamMax(CpuParticles3D_Parameter(8), value)
 
-template scaleAmountCurve*(self: CpuParticles3D): untyped = self.getParamCurve(8)
-template `scaleAmountCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(8, value)
+template scaleAmountCurve*(self: CpuParticles3D): untyped = self.getParamCurve(CpuParticles3D_Parameter(8))
+template `scaleAmountCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(CpuParticles3D_Parameter(8), value)
 
 template splitScale*(self: CpuParticles3D): untyped = self.getSplitScale()
 template `splitScale=`*(self: CpuParticles3D; value) = self.setSplitScale(value)
@@ -652,32 +652,32 @@ template `colorRamp=`*(self: CpuParticles3D; value) = self.setColorRamp(value)
 template colorInitialRamp*(self: CpuParticles3D): untyped = self.getColorInitialRamp()
 template `colorInitialRamp=`*(self: CpuParticles3D; value) = self.setColorInitialRamp(value)
 
-template hueVariationMin*(self: CpuParticles3D): untyped = self.getParamMin(9)
-template `hueVariationMin=`*(self: CpuParticles3D; value) = self.setParamMin(9, value)
+template hueVariationMin*(self: CpuParticles3D): untyped = self.getParamMin(CpuParticles3D_Parameter(9))
+template `hueVariationMin=`*(self: CpuParticles3D; value) = self.setParamMin(CpuParticles3D_Parameter(9), value)
 
-template hueVariationMax*(self: CpuParticles3D): untyped = self.getParamMax(9)
-template `hueVariationMax=`*(self: CpuParticles3D; value) = self.setParamMax(9, value)
+template hueVariationMax*(self: CpuParticles3D): untyped = self.getParamMax(CpuParticles3D_Parameter(9))
+template `hueVariationMax=`*(self: CpuParticles3D; value) = self.setParamMax(CpuParticles3D_Parameter(9), value)
 
-template hueVariationCurve*(self: CpuParticles3D): untyped = self.getParamCurve(9)
-template `hueVariationCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(9, value)
+template hueVariationCurve*(self: CpuParticles3D): untyped = self.getParamCurve(CpuParticles3D_Parameter(9))
+template `hueVariationCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(CpuParticles3D_Parameter(9), value)
 
-template animSpeedMin*(self: CpuParticles3D): untyped = self.getParamMin(10)
-template `animSpeedMin=`*(self: CpuParticles3D; value) = self.setParamMin(10, value)
+template animSpeedMin*(self: CpuParticles3D): untyped = self.getParamMin(CpuParticles3D_Parameter(10))
+template `animSpeedMin=`*(self: CpuParticles3D; value) = self.setParamMin(CpuParticles3D_Parameter(10), value)
 
-template animSpeedMax*(self: CpuParticles3D): untyped = self.getParamMax(10)
-template `animSpeedMax=`*(self: CpuParticles3D; value) = self.setParamMax(10, value)
+template animSpeedMax*(self: CpuParticles3D): untyped = self.getParamMax(CpuParticles3D_Parameter(10))
+template `animSpeedMax=`*(self: CpuParticles3D; value) = self.setParamMax(CpuParticles3D_Parameter(10), value)
 
-template animSpeedCurve*(self: CpuParticles3D): untyped = self.getParamCurve(10)
-template `animSpeedCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(10, value)
+template animSpeedCurve*(self: CpuParticles3D): untyped = self.getParamCurve(CpuParticles3D_Parameter(10))
+template `animSpeedCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(CpuParticles3D_Parameter(10), value)
 
-template animOffsetMin*(self: CpuParticles3D): untyped = self.getParamMin(11)
-template `animOffsetMin=`*(self: CpuParticles3D; value) = self.setParamMin(11, value)
+template animOffsetMin*(self: CpuParticles3D): untyped = self.getParamMin(CpuParticles3D_Parameter(11))
+template `animOffsetMin=`*(self: CpuParticles3D; value) = self.setParamMin(CpuParticles3D_Parameter(11), value)
 
-template animOffsetMax*(self: CpuParticles3D): untyped = self.getParamMax(11)
-template `animOffsetMax=`*(self: CpuParticles3D; value) = self.setParamMax(11, value)
+template animOffsetMax*(self: CpuParticles3D): untyped = self.getParamMax(CpuParticles3D_Parameter(11))
+template `animOffsetMax=`*(self: CpuParticles3D; value) = self.setParamMax(CpuParticles3D_Parameter(11), value)
 
-template animOffsetCurve*(self: CpuParticles3D): untyped = self.getParamCurve(11)
-template `animOffsetCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(11, value)
+template animOffsetCurve*(self: CpuParticles3D): untyped = self.getParamCurve(CpuParticles3D_Parameter(11))
+template `animOffsetCurve=`*(self: CpuParticles3D; value) = self.setParamCurve(CpuParticles3D_Parameter(11), value)
 
 const CpuParticles3D_vmap =
   GeometryInstance3D.vmap.concat initTable[string, string]()

--- a/src/gdext/classes/gddecal.nim
+++ b/src/gdext/classes/gddecal.nim
@@ -140,17 +140,17 @@ proc getCullMask*(self: Decal): uint32 =
 template size*(self: Decal): untyped = self.getSize()
 template `size=`*(self: Decal; value) = self.setSize(value)
 
-template textureAlbedo*(self: Decal): untyped = self.getTexture(0)
-template `textureAlbedo=`*(self: Decal; value) = self.setTexture(0, value)
+template textureAlbedo*(self: Decal): untyped = self.getTexture(Decal_DecalTexture(0))
+template `textureAlbedo=`*(self: Decal; value) = self.setTexture(Decal_DecalTexture(0), value)
 
-template textureNormal*(self: Decal): untyped = self.getTexture(1)
-template `textureNormal=`*(self: Decal; value) = self.setTexture(1, value)
+template textureNormal*(self: Decal): untyped = self.getTexture(Decal_DecalTexture(1))
+template `textureNormal=`*(self: Decal; value) = self.setTexture(Decal_DecalTexture(1), value)
 
-template textureOrm*(self: Decal): untyped = self.getTexture(2)
-template `textureOrm=`*(self: Decal; value) = self.setTexture(2, value)
+template textureOrm*(self: Decal): untyped = self.getTexture(Decal_DecalTexture(2))
+template `textureOrm=`*(self: Decal; value) = self.setTexture(Decal_DecalTexture(2), value)
 
-template textureEmission*(self: Decal): untyped = self.getTexture(3)
-template `textureEmission=`*(self: Decal; value) = self.setTexture(3, value)
+template textureEmission*(self: Decal): untyped = self.getTexture(Decal_DecalTexture(3))
+template `textureEmission=`*(self: Decal; value) = self.setTexture(Decal_DecalTexture(3), value)
 
 template emissionEnergy*(self: Decal): untyped = self.getEmissionEnergy()
 template `emissionEnergy=`*(self: Decal; value) = self.setEmissionEnergy(value)

--- a/src/gdext/classes/gdgpuparticles3d.nim
+++ b/src/gdext/classes/gdgpuparticles3d.nim
@@ -369,17 +369,17 @@ template `processMaterial=`*(self: GpuParticles3D; value) = self.setProcessMater
 template drawPasses*(self: GpuParticles3D): untyped = self.getDrawPasses()
 template `drawPasses=`*(self: GpuParticles3D; value) = self.setDrawPasses(value)
 
-template drawPass1*(self: GpuParticles3D): untyped = self.getDrawPassMesh(0)
-template `drawPass1=`*(self: GpuParticles3D; value) = self.setDrawPassMesh(0, value)
+template drawPass1*(self: GpuParticles3D): untyped = self.getDrawPassMesh(int32(0))
+template `drawPass1=`*(self: GpuParticles3D; value) = self.setDrawPassMesh(int32(0), value)
 
-template drawPass2*(self: GpuParticles3D): untyped = self.getDrawPassMesh(1)
-template `drawPass2=`*(self: GpuParticles3D; value) = self.setDrawPassMesh(1, value)
+template drawPass2*(self: GpuParticles3D): untyped = self.getDrawPassMesh(int32(1))
+template `drawPass2=`*(self: GpuParticles3D; value) = self.setDrawPassMesh(int32(1), value)
 
-template drawPass3*(self: GpuParticles3D): untyped = self.getDrawPassMesh(2)
-template `drawPass3=`*(self: GpuParticles3D; value) = self.setDrawPassMesh(2, value)
+template drawPass3*(self: GpuParticles3D): untyped = self.getDrawPassMesh(int32(2))
+template `drawPass3=`*(self: GpuParticles3D; value) = self.setDrawPassMesh(int32(2), value)
 
-template drawPass4*(self: GpuParticles3D): untyped = self.getDrawPassMesh(3)
-template `drawPass4=`*(self: GpuParticles3D; value) = self.setDrawPassMesh(3, value)
+template drawPass4*(self: GpuParticles3D): untyped = self.getDrawPassMesh(int32(3))
+template `drawPass4=`*(self: GpuParticles3D; value) = self.setDrawPassMesh(int32(3), value)
 
 template drawSkin*(self: GpuParticles3D): untyped = self.getSkin()
 template `drawSkin=`*(self: GpuParticles3D; value) = self.setSkin(value)

--- a/src/gdext/classes/gdimage.nim
+++ b/src/gdext/classes/gdimage.nim
@@ -110,7 +110,7 @@ proc create*(_: typedesc[Image]; width: int32; height: int32; useMipmaps: bool; 
   (addr ret).decode_result(gdref Image)
 
 proc createEmpty*(_: typedesc[Image]; width: int32; height: int32; useMipmaps: bool; format: Image_Format): gdref Image =
-  expandMethodBind(className classindex.Image, "create_empty", 986942177)
+  expandMethodBind(className Image, "create_empty", 986942177)
   var `?param` = [getPtr width, getPtr height, getPtr useMipmaps, getPtr format]
   var ret: encoded gdref Image
   methodbind.ptrcall(addr `?param`[0], addr ret)

--- a/src/gdext/classes/gdlabel3d.nim
+++ b/src/gdext/classes/gdlabel3d.nim
@@ -339,17 +339,17 @@ template `offset=`*(self: Label3D; value) = self.setOffset(value)
 template billboard*(self: Label3D): untyped = self.getBillboardMode()
 template `billboard=`*(self: Label3D; value) = self.setBillboardMode(value)
 
-template shaded*(self: Label3D): untyped = self.getDrawFlag(0)
-template `shaded=`*(self: Label3D; value) = self.setDrawFlag(0, value)
+template shaded*(self: Label3D): untyped = self.getDrawFlag(Label3D_DrawFlags(0))
+template `shaded=`*(self: Label3D; value) = self.setDrawFlag(Label3D_DrawFlags(0), value)
 
-template doubleSided*(self: Label3D): untyped = self.getDrawFlag(1)
-template `doubleSided=`*(self: Label3D; value) = self.setDrawFlag(1, value)
+template doubleSided*(self: Label3D): untyped = self.getDrawFlag(Label3D_DrawFlags(1))
+template `doubleSided=`*(self: Label3D; value) = self.setDrawFlag(Label3D_DrawFlags(1), value)
 
-template noDepthTest*(self: Label3D): untyped = self.getDrawFlag(2)
-template `noDepthTest=`*(self: Label3D; value) = self.setDrawFlag(2, value)
+template noDepthTest*(self: Label3D): untyped = self.getDrawFlag(Label3D_DrawFlags(2))
+template `noDepthTest=`*(self: Label3D; value) = self.setDrawFlag(Label3D_DrawFlags(2), value)
 
-template fixedSize*(self: Label3D): untyped = self.getDrawFlag(3)
-template `fixedSize=`*(self: Label3D; value) = self.setDrawFlag(3, value)
+template fixedSize*(self: Label3D): untyped = self.getDrawFlag(Label3D_DrawFlags(3))
+template `fixedSize=`*(self: Label3D; value) = self.setDrawFlag(Label3D_DrawFlags(3), value)
 
 template alphaCut*(self: Label3D): untyped = self.getAlphaCutMode()
 template `alphaCut=`*(self: Label3D; value) = self.setAlphaCutMode(value)

--- a/src/gdext/classes/gdlight3d.nim
+++ b/src/gdext/classes/gdlight3d.nim
@@ -165,11 +165,11 @@ proc getCorrelatedColor*(self: Light3D): Color =
   methodbind.ptrcall(self, nil, addr ret)
   (addr ret).decode_result(Color)
 
-template lightIntensityLumens*(self: Light3D): untyped = self.getParam(20)
-template `lightIntensityLumens=`*(self: Light3D; value) = self.setParam(20, value)
+template lightIntensityLumens*(self: Light3D): untyped = self.getParam(Light3D_Param(20))
+template `lightIntensityLumens=`*(self: Light3D; value) = self.setParam(Light3D_Param(20), value)
 
-template lightIntensityLux*(self: Light3D): untyped = self.getParam(20)
-template `lightIntensityLux=`*(self: Light3D; value) = self.setParam(20, value)
+template lightIntensityLux*(self: Light3D): untyped = self.getParam(Light3D_Param(20))
+template `lightIntensityLux=`*(self: Light3D; value) = self.setParam(Light3D_Param(20), value)
 
 template lightTemperature*(self: Light3D): untyped = self.getTemperature()
 template `lightTemperature=`*(self: Light3D; value) = self.setTemperature(value)
@@ -177,29 +177,29 @@ template `lightTemperature=`*(self: Light3D; value) = self.setTemperature(value)
 template lightColor*(self: Light3D): untyped = self.getColor()
 template `lightColor=`*(self: Light3D; value) = self.setColor(value)
 
-template lightEnergy*(self: Light3D): untyped = self.getParam(0)
-template `lightEnergy=`*(self: Light3D; value) = self.setParam(0, value)
+template lightEnergy*(self: Light3D): untyped = self.getParam(Light3D_Param(0))
+template `lightEnergy=`*(self: Light3D; value) = self.setParam(Light3D_Param(0), value)
 
-template lightIndirectEnergy*(self: Light3D): untyped = self.getParam(1)
-template `lightIndirectEnergy=`*(self: Light3D; value) = self.setParam(1, value)
+template lightIndirectEnergy*(self: Light3D): untyped = self.getParam(Light3D_Param(1))
+template `lightIndirectEnergy=`*(self: Light3D; value) = self.setParam(Light3D_Param(1), value)
 
-template lightVolumetricFogEnergy*(self: Light3D): untyped = self.getParam(2)
-template `lightVolumetricFogEnergy=`*(self: Light3D; value) = self.setParam(2, value)
+template lightVolumetricFogEnergy*(self: Light3D): untyped = self.getParam(Light3D_Param(2))
+template `lightVolumetricFogEnergy=`*(self: Light3D; value) = self.setParam(Light3D_Param(2), value)
 
 template lightProjector*(self: Light3D): untyped = self.getProjector()
 template `lightProjector=`*(self: Light3D; value) = self.setProjector(value)
 
-template lightSize*(self: Light3D): untyped = self.getParam(5)
-template `lightSize=`*(self: Light3D; value) = self.setParam(5, value)
+template lightSize*(self: Light3D): untyped = self.getParam(Light3D_Param(5))
+template `lightSize=`*(self: Light3D; value) = self.setParam(Light3D_Param(5), value)
 
-template lightAngularDistance*(self: Light3D): untyped = self.getParam(5)
-template `lightAngularDistance=`*(self: Light3D; value) = self.setParam(5, value)
+template lightAngularDistance*(self: Light3D): untyped = self.getParam(Light3D_Param(5))
+template `lightAngularDistance=`*(self: Light3D; value) = self.setParam(Light3D_Param(5), value)
 
 template lightNegative*(self: Light3D): untyped = self.isNegative()
 template `lightNegative=`*(self: Light3D; value) = self.setNegative(value)
 
-template lightSpecular*(self: Light3D): untyped = self.getParam(3)
-template `lightSpecular=`*(self: Light3D; value) = self.setParam(3, value)
+template lightSpecular*(self: Light3D): untyped = self.getParam(Light3D_Param(3))
+template `lightSpecular=`*(self: Light3D; value) = self.setParam(Light3D_Param(3), value)
 
 template lightBakeMode*(self: Light3D): untyped = self.getBakeMode()
 template `lightBakeMode=`*(self: Light3D; value) = self.setBakeMode(value)
@@ -210,23 +210,23 @@ template `lightCullMask=`*(self: Light3D; value) = self.setCullMask(value)
 template shadowEnabled*(self: Light3D): untyped = self.hasShadow()
 template `shadowEnabled=`*(self: Light3D; value) = self.setShadow(value)
 
-template shadowBias*(self: Light3D): untyped = self.getParam(15)
-template `shadowBias=`*(self: Light3D; value) = self.setParam(15, value)
+template shadowBias*(self: Light3D): untyped = self.getParam(Light3D_Param(15))
+template `shadowBias=`*(self: Light3D; value) = self.setParam(Light3D_Param(15), value)
 
-template shadowNormalBias*(self: Light3D): untyped = self.getParam(14)
-template `shadowNormalBias=`*(self: Light3D; value) = self.setParam(14, value)
+template shadowNormalBias*(self: Light3D): untyped = self.getParam(Light3D_Param(14))
+template `shadowNormalBias=`*(self: Light3D; value) = self.setParam(Light3D_Param(14), value)
 
 template shadowReverseCullFace*(self: Light3D): untyped = self.getShadowReverseCullFace()
 template `shadowReverseCullFace=`*(self: Light3D; value) = self.setShadowReverseCullFace(value)
 
-template shadowTransmittanceBias*(self: Light3D): untyped = self.getParam(19)
-template `shadowTransmittanceBias=`*(self: Light3D; value) = self.setParam(19, value)
+template shadowTransmittanceBias*(self: Light3D): untyped = self.getParam(Light3D_Param(19))
+template `shadowTransmittanceBias=`*(self: Light3D; value) = self.setParam(Light3D_Param(19), value)
 
-template shadowOpacity*(self: Light3D): untyped = self.getParam(17)
-template `shadowOpacity=`*(self: Light3D; value) = self.setParam(17, value)
+template shadowOpacity*(self: Light3D): untyped = self.getParam(Light3D_Param(17))
+template `shadowOpacity=`*(self: Light3D; value) = self.setParam(Light3D_Param(17), value)
 
-template shadowBlur*(self: Light3D): untyped = self.getParam(18)
-template `shadowBlur=`*(self: Light3D; value) = self.setParam(18, value)
+template shadowBlur*(self: Light3D): untyped = self.getParam(Light3D_Param(18))
+template `shadowBlur=`*(self: Light3D; value) = self.setParam(Light3D_Param(18), value)
 
 template distanceFadeEnabled*(self: Light3D): untyped = self.isDistanceFadeEnabled()
 template `distanceFadeEnabled=`*(self: Light3D; value) = self.setEnableDistanceFade(value)

--- a/src/gdext/classes/gdninepatchrect.nim
+++ b/src/gdext/classes/gdninepatchrect.nim
@@ -80,17 +80,17 @@ template `drawCenter=`*(self: NinePatchRect; value) = self.setDrawCenter(value)
 template regionRect*(self: NinePatchRect): untyped = self.getRegionRect()
 template `regionRect=`*(self: NinePatchRect; value) = self.setRegionRect(value)
 
-template patchMarginLeft*(self: NinePatchRect): untyped = self.getPatchMargin(0)
-template `patchMarginLeft=`*(self: NinePatchRect; value) = self.setPatchMargin(0, value)
+template patchMarginLeft*(self: NinePatchRect): untyped = self.getPatchMargin(Side(0))
+template `patchMarginLeft=`*(self: NinePatchRect; value) = self.setPatchMargin(Side(0), value)
 
-template patchMarginTop*(self: NinePatchRect): untyped = self.getPatchMargin(1)
-template `patchMarginTop=`*(self: NinePatchRect; value) = self.setPatchMargin(1, value)
+template patchMarginTop*(self: NinePatchRect): untyped = self.getPatchMargin(Side(1))
+template `patchMarginTop=`*(self: NinePatchRect; value) = self.setPatchMargin(Side(1), value)
 
-template patchMarginRight*(self: NinePatchRect): untyped = self.getPatchMargin(2)
-template `patchMarginRight=`*(self: NinePatchRect; value) = self.setPatchMargin(2, value)
+template patchMarginRight*(self: NinePatchRect): untyped = self.getPatchMargin(Side(2))
+template `patchMarginRight=`*(self: NinePatchRect; value) = self.setPatchMargin(Side(2), value)
 
-template patchMarginBottom*(self: NinePatchRect): untyped = self.getPatchMargin(3)
-template `patchMarginBottom=`*(self: NinePatchRect; value) = self.setPatchMargin(3, value)
+template patchMarginBottom*(self: NinePatchRect): untyped = self.getPatchMargin(Side(3))
+template `patchMarginBottom=`*(self: NinePatchRect; value) = self.setPatchMargin(Side(3), value)
 
 template axisStretchHorizontal*(self: NinePatchRect): untyped = self.getHAxisStretchMode()
 template `axisStretchHorizontal=`*(self: NinePatchRect; value) = self.setHAxisStretchMode(value)

--- a/src/gdext/classes/gdnode.nim
+++ b/src/gdext/classes/gdnode.nim
@@ -55,7 +55,7 @@ proc unhandledKeyInput(p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[
 template unhandledKeyInput_bind*(_: typedesc[Node]): ClassCallVirtual = unhandledKeyInput
 
 proc printOrphanNodes*(_: typedesc[Node]): void =
-  expandMethodBind(className(Node), "print_orphan_nodes", 3218959716)
+  expandMethodBind(className Node, "print_orphan_nodes", 3218959716)
   methodbind.ptrcall(nil)
 
 proc addSibling*(self: Node; sibling: Node; forceReadableName: bool = false): void =

--- a/src/gdext/classes/gdparticleprocessmaterial.nim
+++ b/src/gdext/classes/gdparticleprocessmaterial.nim
@@ -518,17 +518,17 @@ proc getCollisionBounce*(self: ParticleProcessMaterial): Float =
 template lifetimeRandomness*(self: ParticleProcessMaterial): untyped = self.getLifetimeRandomness()
 template `lifetimeRandomness=`*(self: ParticleProcessMaterial; value) = self.setLifetimeRandomness(value)
 
-template particleFlagAlignY*(self: ParticleProcessMaterial): untyped = self.getParticleFlag(0)
-template `particleFlagAlignY=`*(self: ParticleProcessMaterial; value) = self.setParticleFlag(0, value)
+template particleFlagAlignY*(self: ParticleProcessMaterial): untyped = self.getParticleFlag(ParticleProcessMaterial_ParticleFlags(0))
+template `particleFlagAlignY=`*(self: ParticleProcessMaterial; value) = self.setParticleFlag(ParticleProcessMaterial_ParticleFlags(0), value)
 
-template particleFlagRotateY*(self: ParticleProcessMaterial): untyped = self.getParticleFlag(1)
-template `particleFlagRotateY=`*(self: ParticleProcessMaterial; value) = self.setParticleFlag(1, value)
+template particleFlagRotateY*(self: ParticleProcessMaterial): untyped = self.getParticleFlag(ParticleProcessMaterial_ParticleFlags(1))
+template `particleFlagRotateY=`*(self: ParticleProcessMaterial; value) = self.setParticleFlag(ParticleProcessMaterial_ParticleFlags(1), value)
 
-template particleFlagDisableZ*(self: ParticleProcessMaterial): untyped = self.getParticleFlag(2)
-template `particleFlagDisableZ=`*(self: ParticleProcessMaterial; value) = self.setParticleFlag(2, value)
+template particleFlagDisableZ*(self: ParticleProcessMaterial): untyped = self.getParticleFlag(ParticleProcessMaterial_ParticleFlags(2))
+template `particleFlagDisableZ=`*(self: ParticleProcessMaterial; value) = self.setParticleFlag(ParticleProcessMaterial_ParticleFlags(2), value)
 
-template particleFlagDampingAsFriction*(self: ParticleProcessMaterial): untyped = self.getParticleFlag(3)
-template `particleFlagDampingAsFriction=`*(self: ParticleProcessMaterial; value) = self.setParticleFlag(3, value)
+template particleFlagDampingAsFriction*(self: ParticleProcessMaterial): untyped = self.getParticleFlag(ParticleProcessMaterial_ParticleFlags(3))
+template `particleFlagDampingAsFriction=`*(self: ParticleProcessMaterial; value) = self.setParticleFlag(ParticleProcessMaterial_ParticleFlags(3), value)
 
 template emissionShapeOffset*(self: ParticleProcessMaterial): untyped = self.getEmissionShapeOffset()
 template `emissionShapeOffset=`*(self: ParticleProcessMaterial; value) = self.setEmissionShapeOffset(value)
@@ -569,17 +569,17 @@ template `emissionRingRadius=`*(self: ParticleProcessMaterial; value) = self.set
 template emissionRingInnerRadius*(self: ParticleProcessMaterial): untyped = self.getEmissionRingInnerRadius()
 template `emissionRingInnerRadius=`*(self: ParticleProcessMaterial; value) = self.setEmissionRingInnerRadius(value)
 
-template angle*(self: ParticleProcessMaterial): untyped = self.getParam(7)
-template `angle=`*(self: ParticleProcessMaterial; value) = self.setParam(7, value)
+template angle*(self: ParticleProcessMaterial): untyped = self.getParam(ParticleProcessMaterial_Parameter(7))
+template `angle=`*(self: ParticleProcessMaterial; value) = self.setParam(ParticleProcessMaterial_Parameter(7), value)
 
-template angleMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(7)
-template `angleMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(7, value)
+template angleMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(ParticleProcessMaterial_Parameter(7))
+template `angleMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(ParticleProcessMaterial_Parameter(7), value)
 
-template angleMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(7)
-template `angleMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(7, value)
+template angleMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(ParticleProcessMaterial_Parameter(7))
+template `angleMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(ParticleProcessMaterial_Parameter(7), value)
 
-template angleCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(7)
-template `angleCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(7, value)
+template angleCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(ParticleProcessMaterial_Parameter(7))
+template `angleCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(ParticleProcessMaterial_Parameter(7), value)
 
 template inheritVelocityRatio*(self: ParticleProcessMaterial): untyped = self.getInheritVelocityRatio()
 template `inheritVelocityRatio=`*(self: ParticleProcessMaterial; value) = self.setInheritVelocityRatio(value)
@@ -596,62 +596,62 @@ template `spread=`*(self: ParticleProcessMaterial; value) = self.setSpread(value
 template flatness*(self: ParticleProcessMaterial): untyped = self.getFlatness()
 template `flatness=`*(self: ParticleProcessMaterial; value) = self.setFlatness(value)
 
-template initialVelocity*(self: ParticleProcessMaterial): untyped = self.getParam(0)
-template `initialVelocity=`*(self: ParticleProcessMaterial; value) = self.setParam(0, value)
+template initialVelocity*(self: ParticleProcessMaterial): untyped = self.getParam(ParticleProcessMaterial_Parameter(0))
+template `initialVelocity=`*(self: ParticleProcessMaterial; value) = self.setParam(ParticleProcessMaterial_Parameter(0), value)
 
-template initialVelocityMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(0)
-template `initialVelocityMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(0, value)
+template initialVelocityMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(ParticleProcessMaterial_Parameter(0))
+template `initialVelocityMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(ParticleProcessMaterial_Parameter(0), value)
 
-template initialVelocityMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(0)
-template `initialVelocityMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(0, value)
+template initialVelocityMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(ParticleProcessMaterial_Parameter(0))
+template `initialVelocityMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(ParticleProcessMaterial_Parameter(0), value)
 
-template angularVelocity*(self: ParticleProcessMaterial): untyped = self.getParam(1)
-template `angularVelocity=`*(self: ParticleProcessMaterial; value) = self.setParam(1, value)
+template angularVelocity*(self: ParticleProcessMaterial): untyped = self.getParam(ParticleProcessMaterial_Parameter(1))
+template `angularVelocity=`*(self: ParticleProcessMaterial; value) = self.setParam(ParticleProcessMaterial_Parameter(1), value)
 
-template angularVelocityMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(1)
-template `angularVelocityMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(1, value)
+template angularVelocityMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(ParticleProcessMaterial_Parameter(1))
+template `angularVelocityMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(ParticleProcessMaterial_Parameter(1), value)
 
-template angularVelocityMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(1)
-template `angularVelocityMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(1, value)
+template angularVelocityMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(ParticleProcessMaterial_Parameter(1))
+template `angularVelocityMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(ParticleProcessMaterial_Parameter(1), value)
 
-template angularVelocityCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(1)
-template `angularVelocityCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(1, value)
+template angularVelocityCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(ParticleProcessMaterial_Parameter(1))
+template `angularVelocityCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(ParticleProcessMaterial_Parameter(1), value)
 
-template directionalVelocity*(self: ParticleProcessMaterial): untyped = self.getParam(16)
-template `directionalVelocity=`*(self: ParticleProcessMaterial; value) = self.setParam(16, value)
+template directionalVelocity*(self: ParticleProcessMaterial): untyped = self.getParam(ParticleProcessMaterial_Parameter(16))
+template `directionalVelocity=`*(self: ParticleProcessMaterial; value) = self.setParam(ParticleProcessMaterial_Parameter(16), value)
 
-template directionalVelocityMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(16)
-template `directionalVelocityMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(16, value)
+template directionalVelocityMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(ParticleProcessMaterial_Parameter(16))
+template `directionalVelocityMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(ParticleProcessMaterial_Parameter(16), value)
 
-template directionalVelocityMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(16)
-template `directionalVelocityMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(16, value)
+template directionalVelocityMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(ParticleProcessMaterial_Parameter(16))
+template `directionalVelocityMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(ParticleProcessMaterial_Parameter(16), value)
 
-template directionalVelocityCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(16)
-template `directionalVelocityCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(16, value)
+template directionalVelocityCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(ParticleProcessMaterial_Parameter(16))
+template `directionalVelocityCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(ParticleProcessMaterial_Parameter(16), value)
 
-template orbitVelocity*(self: ParticleProcessMaterial): untyped = self.getParam(2)
-template `orbitVelocity=`*(self: ParticleProcessMaterial; value) = self.setParam(2, value)
+template orbitVelocity*(self: ParticleProcessMaterial): untyped = self.getParam(ParticleProcessMaterial_Parameter(2))
+template `orbitVelocity=`*(self: ParticleProcessMaterial; value) = self.setParam(ParticleProcessMaterial_Parameter(2), value)
 
-template orbitVelocityMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(2)
-template `orbitVelocityMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(2, value)
+template orbitVelocityMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(ParticleProcessMaterial_Parameter(2))
+template `orbitVelocityMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(ParticleProcessMaterial_Parameter(2), value)
 
-template orbitVelocityMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(2)
-template `orbitVelocityMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(2, value)
+template orbitVelocityMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(ParticleProcessMaterial_Parameter(2))
+template `orbitVelocityMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(ParticleProcessMaterial_Parameter(2), value)
 
-template orbitVelocityCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(2)
-template `orbitVelocityCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(2, value)
+template orbitVelocityCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(ParticleProcessMaterial_Parameter(2))
+template `orbitVelocityCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(ParticleProcessMaterial_Parameter(2), value)
 
-template radialVelocity*(self: ParticleProcessMaterial): untyped = self.getParam(15)
-template `radialVelocity=`*(self: ParticleProcessMaterial; value) = self.setParam(15, value)
+template radialVelocity*(self: ParticleProcessMaterial): untyped = self.getParam(ParticleProcessMaterial_Parameter(15))
+template `radialVelocity=`*(self: ParticleProcessMaterial; value) = self.setParam(ParticleProcessMaterial_Parameter(15), value)
 
-template radialVelocityMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(15)
-template `radialVelocityMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(15, value)
+template radialVelocityMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(ParticleProcessMaterial_Parameter(15))
+template `radialVelocityMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(ParticleProcessMaterial_Parameter(15), value)
 
-template radialVelocityMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(15)
-template `radialVelocityMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(15, value)
+template radialVelocityMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(ParticleProcessMaterial_Parameter(15))
+template `radialVelocityMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(ParticleProcessMaterial_Parameter(15), value)
 
-template radialVelocityCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(15)
-template `radialVelocityCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(15, value)
+template radialVelocityCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(ParticleProcessMaterial_Parameter(15))
+template `radialVelocityCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(ParticleProcessMaterial_Parameter(15), value)
 
 template velocityLimitCurve*(self: ParticleProcessMaterial): untyped = self.getVelocityLimitCurve()
 template `velocityLimitCurve=`*(self: ParticleProcessMaterial; value) = self.setVelocityLimitCurve(value)
@@ -659,80 +659,80 @@ template `velocityLimitCurve=`*(self: ParticleProcessMaterial; value) = self.set
 template gravity*(self: ParticleProcessMaterial): untyped = self.getGravity()
 template `gravity=`*(self: ParticleProcessMaterial; value) = self.setGravity(value)
 
-template linearAccel*(self: ParticleProcessMaterial): untyped = self.getParam(3)
-template `linearAccel=`*(self: ParticleProcessMaterial; value) = self.setParam(3, value)
+template linearAccel*(self: ParticleProcessMaterial): untyped = self.getParam(ParticleProcessMaterial_Parameter(3))
+template `linearAccel=`*(self: ParticleProcessMaterial; value) = self.setParam(ParticleProcessMaterial_Parameter(3), value)
 
-template linearAccelMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(3)
-template `linearAccelMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(3, value)
+template linearAccelMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(ParticleProcessMaterial_Parameter(3))
+template `linearAccelMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(ParticleProcessMaterial_Parameter(3), value)
 
-template linearAccelMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(3)
-template `linearAccelMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(3, value)
+template linearAccelMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(ParticleProcessMaterial_Parameter(3))
+template `linearAccelMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(ParticleProcessMaterial_Parameter(3), value)
 
-template linearAccelCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(3)
-template `linearAccelCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(3, value)
+template linearAccelCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(ParticleProcessMaterial_Parameter(3))
+template `linearAccelCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(ParticleProcessMaterial_Parameter(3), value)
 
-template radialAccel*(self: ParticleProcessMaterial): untyped = self.getParam(4)
-template `radialAccel=`*(self: ParticleProcessMaterial; value) = self.setParam(4, value)
+template radialAccel*(self: ParticleProcessMaterial): untyped = self.getParam(ParticleProcessMaterial_Parameter(4))
+template `radialAccel=`*(self: ParticleProcessMaterial; value) = self.setParam(ParticleProcessMaterial_Parameter(4), value)
 
-template radialAccelMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(4)
-template `radialAccelMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(4, value)
+template radialAccelMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(ParticleProcessMaterial_Parameter(4))
+template `radialAccelMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(ParticleProcessMaterial_Parameter(4), value)
 
-template radialAccelMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(4)
-template `radialAccelMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(4, value)
+template radialAccelMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(ParticleProcessMaterial_Parameter(4))
+template `radialAccelMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(ParticleProcessMaterial_Parameter(4), value)
 
-template radialAccelCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(4)
-template `radialAccelCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(4, value)
+template radialAccelCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(ParticleProcessMaterial_Parameter(4))
+template `radialAccelCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(ParticleProcessMaterial_Parameter(4), value)
 
-template tangentialAccel*(self: ParticleProcessMaterial): untyped = self.getParam(5)
-template `tangentialAccel=`*(self: ParticleProcessMaterial; value) = self.setParam(5, value)
+template tangentialAccel*(self: ParticleProcessMaterial): untyped = self.getParam(ParticleProcessMaterial_Parameter(5))
+template `tangentialAccel=`*(self: ParticleProcessMaterial; value) = self.setParam(ParticleProcessMaterial_Parameter(5), value)
 
-template tangentialAccelMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(5)
-template `tangentialAccelMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(5, value)
+template tangentialAccelMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(ParticleProcessMaterial_Parameter(5))
+template `tangentialAccelMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(ParticleProcessMaterial_Parameter(5), value)
 
-template tangentialAccelMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(5)
-template `tangentialAccelMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(5, value)
+template tangentialAccelMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(ParticleProcessMaterial_Parameter(5))
+template `tangentialAccelMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(ParticleProcessMaterial_Parameter(5), value)
 
-template tangentialAccelCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(5)
-template `tangentialAccelCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(5, value)
+template tangentialAccelCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(ParticleProcessMaterial_Parameter(5))
+template `tangentialAccelCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(ParticleProcessMaterial_Parameter(5), value)
 
-template damping*(self: ParticleProcessMaterial): untyped = self.getParam(6)
-template `damping=`*(self: ParticleProcessMaterial; value) = self.setParam(6, value)
+template damping*(self: ParticleProcessMaterial): untyped = self.getParam(ParticleProcessMaterial_Parameter(6))
+template `damping=`*(self: ParticleProcessMaterial; value) = self.setParam(ParticleProcessMaterial_Parameter(6), value)
 
-template dampingMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(6)
-template `dampingMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(6, value)
+template dampingMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(ParticleProcessMaterial_Parameter(6))
+template `dampingMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(ParticleProcessMaterial_Parameter(6), value)
 
-template dampingMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(6)
-template `dampingMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(6, value)
+template dampingMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(ParticleProcessMaterial_Parameter(6))
+template `dampingMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(ParticleProcessMaterial_Parameter(6), value)
 
-template dampingCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(6)
-template `dampingCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(6, value)
+template dampingCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(ParticleProcessMaterial_Parameter(6))
+template `dampingCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(ParticleProcessMaterial_Parameter(6), value)
 
 template attractorInteractionEnabled*(self: ParticleProcessMaterial): untyped = self.isAttractorInteractionEnabled()
 template `attractorInteractionEnabled=`*(self: ParticleProcessMaterial; value) = self.setAttractorInteractionEnabled(value)
 
-template scale*(self: ParticleProcessMaterial): untyped = self.getParam(8)
-template `scale=`*(self: ParticleProcessMaterial; value) = self.setParam(8, value)
+template scale*(self: ParticleProcessMaterial): untyped = self.getParam(ParticleProcessMaterial_Parameter(8))
+template `scale=`*(self: ParticleProcessMaterial; value) = self.setParam(ParticleProcessMaterial_Parameter(8), value)
 
-template scaleMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(8)
-template `scaleMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(8, value)
+template scaleMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(ParticleProcessMaterial_Parameter(8))
+template `scaleMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(ParticleProcessMaterial_Parameter(8), value)
 
-template scaleMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(8)
-template `scaleMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(8, value)
+template scaleMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(ParticleProcessMaterial_Parameter(8))
+template `scaleMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(ParticleProcessMaterial_Parameter(8), value)
 
-template scaleCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(8)
-template `scaleCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(8, value)
+template scaleCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(ParticleProcessMaterial_Parameter(8))
+template `scaleCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(ParticleProcessMaterial_Parameter(8), value)
 
-template scaleOverVelocity*(self: ParticleProcessMaterial): untyped = self.getParam(17)
-template `scaleOverVelocity=`*(self: ParticleProcessMaterial; value) = self.setParam(17, value)
+template scaleOverVelocity*(self: ParticleProcessMaterial): untyped = self.getParam(ParticleProcessMaterial_Parameter(17))
+template `scaleOverVelocity=`*(self: ParticleProcessMaterial; value) = self.setParam(ParticleProcessMaterial_Parameter(17), value)
 
-template scaleOverVelocityMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(17)
-template `scaleOverVelocityMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(17, value)
+template scaleOverVelocityMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(ParticleProcessMaterial_Parameter(17))
+template `scaleOverVelocityMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(ParticleProcessMaterial_Parameter(17), value)
 
-template scaleOverVelocityMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(17)
-template `scaleOverVelocityMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(17, value)
+template scaleOverVelocityMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(ParticleProcessMaterial_Parameter(17))
+template `scaleOverVelocityMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(ParticleProcessMaterial_Parameter(17), value)
 
-template scaleOverVelocityCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(17)
-template `scaleOverVelocityCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(17, value)
+template scaleOverVelocityCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(ParticleProcessMaterial_Parameter(17))
+template `scaleOverVelocityCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(ParticleProcessMaterial_Parameter(17), value)
 
 template color*(self: ParticleProcessMaterial): untyped = self.getColor()
 template `color=`*(self: ParticleProcessMaterial; value) = self.setColor(value)
@@ -749,41 +749,41 @@ template `alphaCurve=`*(self: ParticleProcessMaterial; value) = self.setAlphaCur
 template emissionCurve*(self: ParticleProcessMaterial): untyped = self.getEmissionCurve()
 template `emissionCurve=`*(self: ParticleProcessMaterial; value) = self.setEmissionCurve(value)
 
-template hueVariation*(self: ParticleProcessMaterial): untyped = self.getParam(9)
-template `hueVariation=`*(self: ParticleProcessMaterial; value) = self.setParam(9, value)
+template hueVariation*(self: ParticleProcessMaterial): untyped = self.getParam(ParticleProcessMaterial_Parameter(9))
+template `hueVariation=`*(self: ParticleProcessMaterial; value) = self.setParam(ParticleProcessMaterial_Parameter(9), value)
 
-template hueVariationMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(9)
-template `hueVariationMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(9, value)
+template hueVariationMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(ParticleProcessMaterial_Parameter(9))
+template `hueVariationMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(ParticleProcessMaterial_Parameter(9), value)
 
-template hueVariationMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(9)
-template `hueVariationMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(9, value)
+template hueVariationMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(ParticleProcessMaterial_Parameter(9))
+template `hueVariationMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(ParticleProcessMaterial_Parameter(9), value)
 
-template hueVariationCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(9)
-template `hueVariationCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(9, value)
+template hueVariationCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(ParticleProcessMaterial_Parameter(9))
+template `hueVariationCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(ParticleProcessMaterial_Parameter(9), value)
 
-template animSpeed*(self: ParticleProcessMaterial): untyped = self.getParam(10)
-template `animSpeed=`*(self: ParticleProcessMaterial; value) = self.setParam(10, value)
+template animSpeed*(self: ParticleProcessMaterial): untyped = self.getParam(ParticleProcessMaterial_Parameter(10))
+template `animSpeed=`*(self: ParticleProcessMaterial; value) = self.setParam(ParticleProcessMaterial_Parameter(10), value)
 
-template animSpeedMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(10)
-template `animSpeedMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(10, value)
+template animSpeedMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(ParticleProcessMaterial_Parameter(10))
+template `animSpeedMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(ParticleProcessMaterial_Parameter(10), value)
 
-template animSpeedMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(10)
-template `animSpeedMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(10, value)
+template animSpeedMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(ParticleProcessMaterial_Parameter(10))
+template `animSpeedMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(ParticleProcessMaterial_Parameter(10), value)
 
-template animSpeedCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(10)
-template `animSpeedCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(10, value)
+template animSpeedCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(ParticleProcessMaterial_Parameter(10))
+template `animSpeedCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(ParticleProcessMaterial_Parameter(10), value)
 
-template animOffset*(self: ParticleProcessMaterial): untyped = self.getParam(11)
-template `animOffset=`*(self: ParticleProcessMaterial; value) = self.setParam(11, value)
+template animOffset*(self: ParticleProcessMaterial): untyped = self.getParam(ParticleProcessMaterial_Parameter(11))
+template `animOffset=`*(self: ParticleProcessMaterial; value) = self.setParam(ParticleProcessMaterial_Parameter(11), value)
 
-template animOffsetMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(11)
-template `animOffsetMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(11, value)
+template animOffsetMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(ParticleProcessMaterial_Parameter(11))
+template `animOffsetMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(ParticleProcessMaterial_Parameter(11), value)
 
-template animOffsetMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(11)
-template `animOffsetMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(11, value)
+template animOffsetMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(ParticleProcessMaterial_Parameter(11))
+template `animOffsetMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(ParticleProcessMaterial_Parameter(11), value)
 
-template animOffsetCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(11)
-template `animOffsetCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(11, value)
+template animOffsetCurve*(self: ParticleProcessMaterial): untyped = self.getParamTexture(ParticleProcessMaterial_Parameter(11))
+template `animOffsetCurve=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(ParticleProcessMaterial_Parameter(11), value)
 
 template turbulenceEnabled*(self: ParticleProcessMaterial): untyped = self.getTurbulenceEnabled()
 template `turbulenceEnabled=`*(self: ParticleProcessMaterial; value) = self.setTurbulenceEnabled(value)
@@ -800,26 +800,26 @@ template `turbulenceNoiseSpeed=`*(self: ParticleProcessMaterial; value) = self.s
 template turbulenceNoiseSpeedRandom*(self: ParticleProcessMaterial): untyped = self.getTurbulenceNoiseSpeedRandom()
 template `turbulenceNoiseSpeedRandom=`*(self: ParticleProcessMaterial; value) = self.setTurbulenceNoiseSpeedRandom(value)
 
-template turbulenceInfluence*(self: ParticleProcessMaterial): untyped = self.getParam(13)
-template `turbulenceInfluence=`*(self: ParticleProcessMaterial; value) = self.setParam(13, value)
+template turbulenceInfluence*(self: ParticleProcessMaterial): untyped = self.getParam(ParticleProcessMaterial_Parameter(13))
+template `turbulenceInfluence=`*(self: ParticleProcessMaterial; value) = self.setParam(ParticleProcessMaterial_Parameter(13), value)
 
-template turbulenceInfluenceMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(13)
-template `turbulenceInfluenceMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(13, value)
+template turbulenceInfluenceMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(ParticleProcessMaterial_Parameter(13))
+template `turbulenceInfluenceMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(ParticleProcessMaterial_Parameter(13), value)
 
-template turbulenceInfluenceMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(13)
-template `turbulenceInfluenceMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(13, value)
+template turbulenceInfluenceMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(ParticleProcessMaterial_Parameter(13))
+template `turbulenceInfluenceMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(ParticleProcessMaterial_Parameter(13), value)
 
-template turbulenceInitialDisplacement*(self: ParticleProcessMaterial): untyped = self.getParam(14)
-template `turbulenceInitialDisplacement=`*(self: ParticleProcessMaterial; value) = self.setParam(14, value)
+template turbulenceInitialDisplacement*(self: ParticleProcessMaterial): untyped = self.getParam(ParticleProcessMaterial_Parameter(14))
+template `turbulenceInitialDisplacement=`*(self: ParticleProcessMaterial; value) = self.setParam(ParticleProcessMaterial_Parameter(14), value)
 
-template turbulenceInitialDisplacementMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(14)
-template `turbulenceInitialDisplacementMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(14, value)
+template turbulenceInitialDisplacementMin*(self: ParticleProcessMaterial): untyped = self.getParamMin(ParticleProcessMaterial_Parameter(14))
+template `turbulenceInitialDisplacementMin=`*(self: ParticleProcessMaterial; value) = self.setParamMin(ParticleProcessMaterial_Parameter(14), value)
 
-template turbulenceInitialDisplacementMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(14)
-template `turbulenceInitialDisplacementMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(14, value)
+template turbulenceInitialDisplacementMax*(self: ParticleProcessMaterial): untyped = self.getParamMax(ParticleProcessMaterial_Parameter(14))
+template `turbulenceInitialDisplacementMax=`*(self: ParticleProcessMaterial; value) = self.setParamMax(ParticleProcessMaterial_Parameter(14), value)
 
-template turbulenceInfluenceOverLife*(self: ParticleProcessMaterial): untyped = self.getParamTexture(12)
-template `turbulenceInfluenceOverLife=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(12, value)
+template turbulenceInfluenceOverLife*(self: ParticleProcessMaterial): untyped = self.getParamTexture(ParticleProcessMaterial_Parameter(12))
+template `turbulenceInfluenceOverLife=`*(self: ParticleProcessMaterial; value) = self.setParamTexture(ParticleProcessMaterial_Parameter(12), value)
 
 template collisionMode*(self: ParticleProcessMaterial): untyped = self.getCollisionMode()
 template `collisionMode=`*(self: ParticleProcessMaterial; value) = self.setCollisionMode(value)

--- a/src/gdext/classes/gdphysicsbody3d.nim
+++ b/src/gdext/classes/gdphysicsbody3d.nim
@@ -52,23 +52,23 @@ proc removeCollisionExceptionWith*(self: PhysicsBody3D; body: Node): void =
   var `?param` = [getPtr body]
   methodbind.ptrcall(self, addr `?param`[0])
 
-template axisLockLinearX*(self: PhysicsBody3D): untyped = self.getAxisLock(1)
-template `axisLockLinearX=`*(self: PhysicsBody3D; value) = self.setAxisLock(1, value)
+template axisLockLinearX*(self: PhysicsBody3D): untyped = self.getAxisLock(PhysicsServer3D_BodyAxis(1))
+template `axisLockLinearX=`*(self: PhysicsBody3D; value) = self.setAxisLock(PhysicsServer3D_BodyAxis(1), value)
 
-template axisLockLinearY*(self: PhysicsBody3D): untyped = self.getAxisLock(2)
-template `axisLockLinearY=`*(self: PhysicsBody3D; value) = self.setAxisLock(2, value)
+template axisLockLinearY*(self: PhysicsBody3D): untyped = self.getAxisLock(PhysicsServer3D_BodyAxis(2))
+template `axisLockLinearY=`*(self: PhysicsBody3D; value) = self.setAxisLock(PhysicsServer3D_BodyAxis(2), value)
 
-template axisLockLinearZ*(self: PhysicsBody3D): untyped = self.getAxisLock(4)
-template `axisLockLinearZ=`*(self: PhysicsBody3D; value) = self.setAxisLock(4, value)
+template axisLockLinearZ*(self: PhysicsBody3D): untyped = self.getAxisLock(PhysicsServer3D_BodyAxis(4))
+template `axisLockLinearZ=`*(self: PhysicsBody3D; value) = self.setAxisLock(PhysicsServer3D_BodyAxis(4), value)
 
-template axisLockAngularX*(self: PhysicsBody3D): untyped = self.getAxisLock(8)
-template `axisLockAngularX=`*(self: PhysicsBody3D; value) = self.setAxisLock(8, value)
+template axisLockAngularX*(self: PhysicsBody3D): untyped = self.getAxisLock(PhysicsServer3D_BodyAxis(8))
+template `axisLockAngularX=`*(self: PhysicsBody3D; value) = self.setAxisLock(PhysicsServer3D_BodyAxis(8), value)
 
-template axisLockAngularY*(self: PhysicsBody3D): untyped = self.getAxisLock(16)
-template `axisLockAngularY=`*(self: PhysicsBody3D; value) = self.setAxisLock(16, value)
+template axisLockAngularY*(self: PhysicsBody3D): untyped = self.getAxisLock(PhysicsServer3D_BodyAxis(16))
+template `axisLockAngularY=`*(self: PhysicsBody3D; value) = self.setAxisLock(PhysicsServer3D_BodyAxis(16), value)
 
-template axisLockAngularZ*(self: PhysicsBody3D): untyped = self.getAxisLock(32)
-template `axisLockAngularZ=`*(self: PhysicsBody3D; value) = self.setAxisLock(32, value)
+template axisLockAngularZ*(self: PhysicsBody3D): untyped = self.getAxisLock(PhysicsServer3D_BodyAxis(32))
+template `axisLockAngularZ=`*(self: PhysicsBody3D; value) = self.setAxisLock(PhysicsServer3D_BodyAxis(32), value)
 
 const PhysicsBody3D_vmap =
   CollisionObject3D.vmap.concat initTable[string, string]()

--- a/src/gdext/classes/gdrdshadersource.nim
+++ b/src/gdext/classes/gdrdshadersource.nim
@@ -27,20 +27,20 @@ proc getLanguage*(self: RdShaderSource): RenderingDevice_ShaderLanguage =
   methodbind.ptrcall(self, nil, addr ret)
   (addr ret).decode_result(RenderingDevice_ShaderLanguage)
 
-template sourceVertex*(self: RdShaderSource): untyped = self.getStageSource(0)
-template `sourceVertex=`*(self: RdShaderSource; value) = self.setStageSource(0, value)
+template sourceVertex*(self: RdShaderSource): untyped = self.getStageSource(RenderingDevice_ShaderStage(0))
+template `sourceVertex=`*(self: RdShaderSource; value) = self.setStageSource(RenderingDevice_ShaderStage(0), value)
 
-template sourceFragment*(self: RdShaderSource): untyped = self.getStageSource(1)
-template `sourceFragment=`*(self: RdShaderSource; value) = self.setStageSource(1, value)
+template sourceFragment*(self: RdShaderSource): untyped = self.getStageSource(RenderingDevice_ShaderStage(1))
+template `sourceFragment=`*(self: RdShaderSource; value) = self.setStageSource(RenderingDevice_ShaderStage(1), value)
 
-template sourceTesselationControl*(self: RdShaderSource): untyped = self.getStageSource(2)
-template `sourceTesselationControl=`*(self: RdShaderSource; value) = self.setStageSource(2, value)
+template sourceTesselationControl*(self: RdShaderSource): untyped = self.getStageSource(RenderingDevice_ShaderStage(2))
+template `sourceTesselationControl=`*(self: RdShaderSource; value) = self.setStageSource(RenderingDevice_ShaderStage(2), value)
 
-template sourceTesselationEvaluation*(self: RdShaderSource): untyped = self.getStageSource(3)
-template `sourceTesselationEvaluation=`*(self: RdShaderSource; value) = self.setStageSource(3, value)
+template sourceTesselationEvaluation*(self: RdShaderSource): untyped = self.getStageSource(RenderingDevice_ShaderStage(3))
+template `sourceTesselationEvaluation=`*(self: RdShaderSource; value) = self.setStageSource(RenderingDevice_ShaderStage(3), value)
 
-template sourceCompute*(self: RdShaderSource): untyped = self.getStageSource(4)
-template `sourceCompute=`*(self: RdShaderSource; value) = self.setStageSource(4, value)
+template sourceCompute*(self: RdShaderSource): untyped = self.getStageSource(RenderingDevice_ShaderStage(4))
+template `sourceCompute=`*(self: RdShaderSource; value) = self.setStageSource(RenderingDevice_ShaderStage(4), value)
 
 template language*(self: RdShaderSource): untyped = self.getLanguage()
 template `language=`*(self: RdShaderSource; value) = self.setLanguage(value)

--- a/src/gdext/classes/gdrdshaderspirv.nim
+++ b/src/gdext/classes/gdrdshaderspirv.nim
@@ -28,35 +28,35 @@ proc getStageCompileError*(self: RdShaderSpirv; stage: RenderingDevice_ShaderSta
   methodbind.ptrcall(self, addr `?param`[0], addr ret)
   (addr ret).decode_result(String)
 
-template bytecodeVertex*(self: RdShaderSpirv): untyped = self.getStageBytecode(0)
-template `bytecodeVertex=`*(self: RdShaderSpirv; value) = self.setStageBytecode(0, value)
+template bytecodeVertex*(self: RdShaderSpirv): untyped = self.getStageBytecode(RenderingDevice_ShaderStage(0))
+template `bytecodeVertex=`*(self: RdShaderSpirv; value) = self.setStageBytecode(RenderingDevice_ShaderStage(0), value)
 
-template bytecodeFragment*(self: RdShaderSpirv): untyped = self.getStageBytecode(1)
-template `bytecodeFragment=`*(self: RdShaderSpirv; value) = self.setStageBytecode(1, value)
+template bytecodeFragment*(self: RdShaderSpirv): untyped = self.getStageBytecode(RenderingDevice_ShaderStage(1))
+template `bytecodeFragment=`*(self: RdShaderSpirv; value) = self.setStageBytecode(RenderingDevice_ShaderStage(1), value)
 
-template bytecodeTesselationControl*(self: RdShaderSpirv): untyped = self.getStageBytecode(2)
-template `bytecodeTesselationControl=`*(self: RdShaderSpirv; value) = self.setStageBytecode(2, value)
+template bytecodeTesselationControl*(self: RdShaderSpirv): untyped = self.getStageBytecode(RenderingDevice_ShaderStage(2))
+template `bytecodeTesselationControl=`*(self: RdShaderSpirv; value) = self.setStageBytecode(RenderingDevice_ShaderStage(2), value)
 
-template bytecodeTesselationEvaluation*(self: RdShaderSpirv): untyped = self.getStageBytecode(3)
-template `bytecodeTesselationEvaluation=`*(self: RdShaderSpirv; value) = self.setStageBytecode(3, value)
+template bytecodeTesselationEvaluation*(self: RdShaderSpirv): untyped = self.getStageBytecode(RenderingDevice_ShaderStage(3))
+template `bytecodeTesselationEvaluation=`*(self: RdShaderSpirv; value) = self.setStageBytecode(RenderingDevice_ShaderStage(3), value)
 
-template bytecodeCompute*(self: RdShaderSpirv): untyped = self.getStageBytecode(4)
-template `bytecodeCompute=`*(self: RdShaderSpirv; value) = self.setStageBytecode(4, value)
+template bytecodeCompute*(self: RdShaderSpirv): untyped = self.getStageBytecode(RenderingDevice_ShaderStage(4))
+template `bytecodeCompute=`*(self: RdShaderSpirv; value) = self.setStageBytecode(RenderingDevice_ShaderStage(4), value)
 
-template compileErrorVertex*(self: RdShaderSpirv): untyped = self.getStageCompileError(0)
-template `compileErrorVertex=`*(self: RdShaderSpirv; value) = self.setStageCompileError(0, value)
+template compileErrorVertex*(self: RdShaderSpirv): untyped = self.getStageCompileError(RenderingDevice_ShaderStage(0))
+template `compileErrorVertex=`*(self: RdShaderSpirv; value) = self.setStageCompileError(RenderingDevice_ShaderStage(0), value)
 
-template compileErrorFragment*(self: RdShaderSpirv): untyped = self.getStageCompileError(1)
-template `compileErrorFragment=`*(self: RdShaderSpirv; value) = self.setStageCompileError(1, value)
+template compileErrorFragment*(self: RdShaderSpirv): untyped = self.getStageCompileError(RenderingDevice_ShaderStage(1))
+template `compileErrorFragment=`*(self: RdShaderSpirv; value) = self.setStageCompileError(RenderingDevice_ShaderStage(1), value)
 
-template compileErrorTesselationControl*(self: RdShaderSpirv): untyped = self.getStageCompileError(2)
-template `compileErrorTesselationControl=`*(self: RdShaderSpirv; value) = self.setStageCompileError(2, value)
+template compileErrorTesselationControl*(self: RdShaderSpirv): untyped = self.getStageCompileError(RenderingDevice_ShaderStage(2))
+template `compileErrorTesselationControl=`*(self: RdShaderSpirv; value) = self.setStageCompileError(RenderingDevice_ShaderStage(2), value)
 
-template compileErrorTesselationEvaluation*(self: RdShaderSpirv): untyped = self.getStageCompileError(3)
-template `compileErrorTesselationEvaluation=`*(self: RdShaderSpirv; value) = self.setStageCompileError(3, value)
+template compileErrorTesselationEvaluation*(self: RdShaderSpirv): untyped = self.getStageCompileError(RenderingDevice_ShaderStage(3))
+template `compileErrorTesselationEvaluation=`*(self: RdShaderSpirv; value) = self.setStageCompileError(RenderingDevice_ShaderStage(3), value)
 
-template compileErrorCompute*(self: RdShaderSpirv): untyped = self.getStageCompileError(4)
-template `compileErrorCompute=`*(self: RdShaderSpirv; value) = self.setStageCompileError(4, value)
+template compileErrorCompute*(self: RdShaderSpirv): untyped = self.getStageCompileError(RenderingDevice_ShaderStage(4))
+template `compileErrorCompute=`*(self: RdShaderSpirv; value) = self.setStageCompileError(RenderingDevice_ShaderStage(4), value)
 
 const RdShaderSpirv_vmap =
   Resource.vmap.concat initTable[string, string]()

--- a/src/gdext/classes/gdspritebase3d.nim
+++ b/src/gdext/classes/gdspritebase3d.nim
@@ -217,20 +217,20 @@ template `axis=`*(self: SpriteBase3D; value) = self.setAxis(value)
 template billboard*(self: SpriteBase3D): untyped = self.getBillboardMode()
 template `billboard=`*(self: SpriteBase3D; value) = self.setBillboardMode(value)
 
-template transparent*(self: SpriteBase3D): untyped = self.getDrawFlag(0)
-template `transparent=`*(self: SpriteBase3D; value) = self.setDrawFlag(0, value)
+template transparent*(self: SpriteBase3D): untyped = self.getDrawFlag(SpriteBase3D_DrawFlags(0))
+template `transparent=`*(self: SpriteBase3D; value) = self.setDrawFlag(SpriteBase3D_DrawFlags(0), value)
 
-template shaded*(self: SpriteBase3D): untyped = self.getDrawFlag(1)
-template `shaded=`*(self: SpriteBase3D; value) = self.setDrawFlag(1, value)
+template shaded*(self: SpriteBase3D): untyped = self.getDrawFlag(SpriteBase3D_DrawFlags(1))
+template `shaded=`*(self: SpriteBase3D; value) = self.setDrawFlag(SpriteBase3D_DrawFlags(1), value)
 
-template doubleSided*(self: SpriteBase3D): untyped = self.getDrawFlag(2)
-template `doubleSided=`*(self: SpriteBase3D; value) = self.setDrawFlag(2, value)
+template doubleSided*(self: SpriteBase3D): untyped = self.getDrawFlag(SpriteBase3D_DrawFlags(2))
+template `doubleSided=`*(self: SpriteBase3D; value) = self.setDrawFlag(SpriteBase3D_DrawFlags(2), value)
 
-template noDepthTest*(self: SpriteBase3D): untyped = self.getDrawFlag(3)
-template `noDepthTest=`*(self: SpriteBase3D; value) = self.setDrawFlag(3, value)
+template noDepthTest*(self: SpriteBase3D): untyped = self.getDrawFlag(SpriteBase3D_DrawFlags(3))
+template `noDepthTest=`*(self: SpriteBase3D; value) = self.setDrawFlag(SpriteBase3D_DrawFlags(3), value)
 
-template fixedSize*(self: SpriteBase3D): untyped = self.getDrawFlag(4)
-template `fixedSize=`*(self: SpriteBase3D; value) = self.setDrawFlag(4, value)
+template fixedSize*(self: SpriteBase3D): untyped = self.getDrawFlag(SpriteBase3D_DrawFlags(4))
+template `fixedSize=`*(self: SpriteBase3D; value) = self.setDrawFlag(SpriteBase3D_DrawFlags(4), value)
 
 template alphaCut*(self: SpriteBase3D): untyped = self.getAlphaCutMode()
 template `alphaCut=`*(self: SpriteBase3D; value) = self.setAlphaCutMode(value)

--- a/src/gdext/classes/gdstylebox.nim
+++ b/src/gdext/classes/gdstylebox.nim
@@ -78,17 +78,17 @@ proc testMask*(self: StyleBox; point: Vector2; rect: Rect2): bool =
   methodbind.ptrcall(self, addr `?param`[0], addr ret)
   (addr ret).decode_result(bool)
 
-template contentMarginLeft*(self: StyleBox): untyped = self.getContentMargin(0)
-template `contentMarginLeft=`*(self: StyleBox; value) = self.setContentMargin(0, value)
+template contentMarginLeft*(self: StyleBox): untyped = self.getContentMargin(Side(0))
+template `contentMarginLeft=`*(self: StyleBox; value) = self.setContentMargin(Side(0), value)
 
-template contentMarginTop*(self: StyleBox): untyped = self.getContentMargin(1)
-template `contentMarginTop=`*(self: StyleBox; value) = self.setContentMargin(1, value)
+template contentMarginTop*(self: StyleBox): untyped = self.getContentMargin(Side(1))
+template `contentMarginTop=`*(self: StyleBox; value) = self.setContentMargin(Side(1), value)
 
-template contentMarginRight*(self: StyleBox): untyped = self.getContentMargin(2)
-template `contentMarginRight=`*(self: StyleBox; value) = self.setContentMargin(2, value)
+template contentMarginRight*(self: StyleBox): untyped = self.getContentMargin(Side(2))
+template `contentMarginRight=`*(self: StyleBox; value) = self.setContentMargin(Side(2), value)
 
-template contentMarginBottom*(self: StyleBox): untyped = self.getContentMargin(3)
-template `contentMarginBottom=`*(self: StyleBox; value) = self.setContentMargin(3, value)
+template contentMarginBottom*(self: StyleBox): untyped = self.getContentMargin(Side(3))
+template `contentMarginBottom=`*(self: StyleBox; value) = self.setContentMargin(Side(3), value)
 
 const StyleBox_vmap =
   Resource.vmap.concat toTable {

--- a/src/gdext/classes/gdstyleboxflat.nim
+++ b/src/gdext/classes/gdstyleboxflat.nim
@@ -191,17 +191,17 @@ template `drawCenter=`*(self: StyleBoxFlat; value) = self.setDrawCenter(value)
 template skew*(self: StyleBoxFlat): untyped = self.getSkew()
 template `skew=`*(self: StyleBoxFlat; value) = self.setSkew(value)
 
-template borderWidthLeft*(self: StyleBoxFlat): untyped = self.getBorderWidth(0)
-template `borderWidthLeft=`*(self: StyleBoxFlat; value) = self.setBorderWidth(0, value)
+template borderWidthLeft*(self: StyleBoxFlat): untyped = self.getBorderWidth(Side(0))
+template `borderWidthLeft=`*(self: StyleBoxFlat; value) = self.setBorderWidth(Side(0), value)
 
-template borderWidthTop*(self: StyleBoxFlat): untyped = self.getBorderWidth(1)
-template `borderWidthTop=`*(self: StyleBoxFlat; value) = self.setBorderWidth(1, value)
+template borderWidthTop*(self: StyleBoxFlat): untyped = self.getBorderWidth(Side(1))
+template `borderWidthTop=`*(self: StyleBoxFlat; value) = self.setBorderWidth(Side(1), value)
 
-template borderWidthRight*(self: StyleBoxFlat): untyped = self.getBorderWidth(2)
-template `borderWidthRight=`*(self: StyleBoxFlat; value) = self.setBorderWidth(2, value)
+template borderWidthRight*(self: StyleBoxFlat): untyped = self.getBorderWidth(Side(2))
+template `borderWidthRight=`*(self: StyleBoxFlat; value) = self.setBorderWidth(Side(2), value)
 
-template borderWidthBottom*(self: StyleBoxFlat): untyped = self.getBorderWidth(3)
-template `borderWidthBottom=`*(self: StyleBoxFlat; value) = self.setBorderWidth(3, value)
+template borderWidthBottom*(self: StyleBoxFlat): untyped = self.getBorderWidth(Side(3))
+template `borderWidthBottom=`*(self: StyleBoxFlat; value) = self.setBorderWidth(Side(3), value)
 
 template borderColor*(self: StyleBoxFlat): untyped = self.getBorderColor()
 template `borderColor=`*(self: StyleBoxFlat; value) = self.setBorderColor(value)
@@ -209,32 +209,32 @@ template `borderColor=`*(self: StyleBoxFlat; value) = self.setBorderColor(value)
 template borderBlend*(self: StyleBoxFlat): untyped = self.getBorderBlend()
 template `borderBlend=`*(self: StyleBoxFlat; value) = self.setBorderBlend(value)
 
-template cornerRadiusTopLeft*(self: StyleBoxFlat): untyped = self.getCornerRadius(0)
-template `cornerRadiusTopLeft=`*(self: StyleBoxFlat; value) = self.setCornerRadius(0, value)
+template cornerRadiusTopLeft*(self: StyleBoxFlat): untyped = self.getCornerRadius(Corner(0))
+template `cornerRadiusTopLeft=`*(self: StyleBoxFlat; value) = self.setCornerRadius(Corner(0), value)
 
-template cornerRadiusTopRight*(self: StyleBoxFlat): untyped = self.getCornerRadius(1)
-template `cornerRadiusTopRight=`*(self: StyleBoxFlat; value) = self.setCornerRadius(1, value)
+template cornerRadiusTopRight*(self: StyleBoxFlat): untyped = self.getCornerRadius(Corner(1))
+template `cornerRadiusTopRight=`*(self: StyleBoxFlat; value) = self.setCornerRadius(Corner(1), value)
 
-template cornerRadiusBottomRight*(self: StyleBoxFlat): untyped = self.getCornerRadius(2)
-template `cornerRadiusBottomRight=`*(self: StyleBoxFlat; value) = self.setCornerRadius(2, value)
+template cornerRadiusBottomRight*(self: StyleBoxFlat): untyped = self.getCornerRadius(Corner(2))
+template `cornerRadiusBottomRight=`*(self: StyleBoxFlat; value) = self.setCornerRadius(Corner(2), value)
 
-template cornerRadiusBottomLeft*(self: StyleBoxFlat): untyped = self.getCornerRadius(3)
-template `cornerRadiusBottomLeft=`*(self: StyleBoxFlat; value) = self.setCornerRadius(3, value)
+template cornerRadiusBottomLeft*(self: StyleBoxFlat): untyped = self.getCornerRadius(Corner(3))
+template `cornerRadiusBottomLeft=`*(self: StyleBoxFlat; value) = self.setCornerRadius(Corner(3), value)
 
 template cornerDetail*(self: StyleBoxFlat): untyped = self.getCornerDetail()
 template `cornerDetail=`*(self: StyleBoxFlat; value) = self.setCornerDetail(value)
 
-template expandMarginLeft*(self: StyleBoxFlat): untyped = self.getExpandMargin(0)
-template `expandMarginLeft=`*(self: StyleBoxFlat; value) = self.setExpandMargin(0, value)
+template expandMarginLeft*(self: StyleBoxFlat): untyped = self.getExpandMargin(Side(0))
+template `expandMarginLeft=`*(self: StyleBoxFlat; value) = self.setExpandMargin(Side(0), value)
 
-template expandMarginTop*(self: StyleBoxFlat): untyped = self.getExpandMargin(1)
-template `expandMarginTop=`*(self: StyleBoxFlat; value) = self.setExpandMargin(1, value)
+template expandMarginTop*(self: StyleBoxFlat): untyped = self.getExpandMargin(Side(1))
+template `expandMarginTop=`*(self: StyleBoxFlat; value) = self.setExpandMargin(Side(1), value)
 
-template expandMarginRight*(self: StyleBoxFlat): untyped = self.getExpandMargin(2)
-template `expandMarginRight=`*(self: StyleBoxFlat; value) = self.setExpandMargin(2, value)
+template expandMarginRight*(self: StyleBoxFlat): untyped = self.getExpandMargin(Side(2))
+template `expandMarginRight=`*(self: StyleBoxFlat; value) = self.setExpandMargin(Side(2), value)
 
-template expandMarginBottom*(self: StyleBoxFlat): untyped = self.getExpandMargin(3)
-template `expandMarginBottom=`*(self: StyleBoxFlat; value) = self.setExpandMargin(3, value)
+template expandMarginBottom*(self: StyleBoxFlat): untyped = self.getExpandMargin(Side(3))
+template `expandMarginBottom=`*(self: StyleBoxFlat; value) = self.setExpandMargin(Side(3), value)
 
 template shadowColor*(self: StyleBoxFlat): untyped = self.getShadowColor()
 template `shadowColor=`*(self: StyleBoxFlat; value) = self.setShadowColor(value)

--- a/src/gdext/classes/gdstyleboxtexture.nim
+++ b/src/gdext/classes/gdstyleboxtexture.nim
@@ -107,29 +107,29 @@ proc getVAxisStretchMode*(self: StyleBoxTexture): StyleBoxTexture_AxisStretchMod
 template texture*(self: StyleBoxTexture): untyped = self.getTexture()
 template `texture=`*(self: StyleBoxTexture; value) = self.setTexture(value)
 
-template textureMarginLeft*(self: StyleBoxTexture): untyped = self.getTextureMargin(0)
-template `textureMarginLeft=`*(self: StyleBoxTexture; value) = self.setTextureMargin(0, value)
+template textureMarginLeft*(self: StyleBoxTexture): untyped = self.getTextureMargin(Side(0))
+template `textureMarginLeft=`*(self: StyleBoxTexture; value) = self.setTextureMargin(Side(0), value)
 
-template textureMarginTop*(self: StyleBoxTexture): untyped = self.getTextureMargin(1)
-template `textureMarginTop=`*(self: StyleBoxTexture; value) = self.setTextureMargin(1, value)
+template textureMarginTop*(self: StyleBoxTexture): untyped = self.getTextureMargin(Side(1))
+template `textureMarginTop=`*(self: StyleBoxTexture; value) = self.setTextureMargin(Side(1), value)
 
-template textureMarginRight*(self: StyleBoxTexture): untyped = self.getTextureMargin(2)
-template `textureMarginRight=`*(self: StyleBoxTexture; value) = self.setTextureMargin(2, value)
+template textureMarginRight*(self: StyleBoxTexture): untyped = self.getTextureMargin(Side(2))
+template `textureMarginRight=`*(self: StyleBoxTexture; value) = self.setTextureMargin(Side(2), value)
 
-template textureMarginBottom*(self: StyleBoxTexture): untyped = self.getTextureMargin(3)
-template `textureMarginBottom=`*(self: StyleBoxTexture; value) = self.setTextureMargin(3, value)
+template textureMarginBottom*(self: StyleBoxTexture): untyped = self.getTextureMargin(Side(3))
+template `textureMarginBottom=`*(self: StyleBoxTexture; value) = self.setTextureMargin(Side(3), value)
 
-template expandMarginLeft*(self: StyleBoxTexture): untyped = self.getExpandMargin(0)
-template `expandMarginLeft=`*(self: StyleBoxTexture; value) = self.setExpandMargin(0, value)
+template expandMarginLeft*(self: StyleBoxTexture): untyped = self.getExpandMargin(Side(0))
+template `expandMarginLeft=`*(self: StyleBoxTexture; value) = self.setExpandMargin(Side(0), value)
 
-template expandMarginTop*(self: StyleBoxTexture): untyped = self.getExpandMargin(1)
-template `expandMarginTop=`*(self: StyleBoxTexture; value) = self.setExpandMargin(1, value)
+template expandMarginTop*(self: StyleBoxTexture): untyped = self.getExpandMargin(Side(1))
+template `expandMarginTop=`*(self: StyleBoxTexture; value) = self.setExpandMargin(Side(1), value)
 
-template expandMarginRight*(self: StyleBoxTexture): untyped = self.getExpandMargin(2)
-template `expandMarginRight=`*(self: StyleBoxTexture; value) = self.setExpandMargin(2, value)
+template expandMarginRight*(self: StyleBoxTexture): untyped = self.getExpandMargin(Side(2))
+template `expandMarginRight=`*(self: StyleBoxTexture; value) = self.setExpandMargin(Side(2), value)
 
-template expandMarginBottom*(self: StyleBoxTexture): untyped = self.getExpandMargin(3)
-template `expandMarginBottom=`*(self: StyleBoxTexture; value) = self.setExpandMargin(3, value)
+template expandMarginBottom*(self: StyleBoxTexture): untyped = self.getExpandMargin(Side(3))
+template `expandMarginBottom=`*(self: StyleBoxTexture; value) = self.setExpandMargin(Side(3), value)
 
 template axisStretchHorizontal*(self: StyleBoxTexture): untyped = self.getHAxisStretchMode()
 template `axisStretchHorizontal=`*(self: StyleBoxTexture; value) = self.setHAxisStretchMode(value)

--- a/src/gdext/classes/gdtextureprogressbar.nim
+++ b/src/gdext/classes/gdtextureprogressbar.nim
@@ -163,17 +163,17 @@ template `radialCenterOffset=`*(self: TextureProgressBar; value) = self.setRadia
 template ninePatchStretch*(self: TextureProgressBar): untyped = self.getNinePatchStretch()
 template `ninePatchStretch=`*(self: TextureProgressBar; value) = self.setNinePatchStretch(value)
 
-template stretchMarginLeft*(self: TextureProgressBar): untyped = self.getStretchMargin(0)
-template `stretchMarginLeft=`*(self: TextureProgressBar; value) = self.setStretchMargin(0, value)
+template stretchMarginLeft*(self: TextureProgressBar): untyped = self.getStretchMargin(Side(0))
+template `stretchMarginLeft=`*(self: TextureProgressBar; value) = self.setStretchMargin(Side(0), value)
 
-template stretchMarginTop*(self: TextureProgressBar): untyped = self.getStretchMargin(1)
-template `stretchMarginTop=`*(self: TextureProgressBar; value) = self.setStretchMargin(1, value)
+template stretchMarginTop*(self: TextureProgressBar): untyped = self.getStretchMargin(Side(1))
+template `stretchMarginTop=`*(self: TextureProgressBar; value) = self.setStretchMargin(Side(1), value)
 
-template stretchMarginRight*(self: TextureProgressBar): untyped = self.getStretchMargin(2)
-template `stretchMarginRight=`*(self: TextureProgressBar; value) = self.setStretchMargin(2, value)
+template stretchMarginRight*(self: TextureProgressBar): untyped = self.getStretchMargin(Side(2))
+template `stretchMarginRight=`*(self: TextureProgressBar; value) = self.setStretchMargin(Side(2), value)
 
-template stretchMarginBottom*(self: TextureProgressBar): untyped = self.getStretchMargin(3)
-template `stretchMarginBottom=`*(self: TextureProgressBar; value) = self.setStretchMargin(3, value)
+template stretchMarginBottom*(self: TextureProgressBar): untyped = self.getStretchMargin(Side(3))
+template `stretchMarginBottom=`*(self: TextureProgressBar; value) = self.setStretchMargin(Side(3), value)
 
 template textureUnder*(self: TextureProgressBar): untyped = self.getUnderTexture()
 template `textureUnder=`*(self: TextureProgressBar; value) = self.setUnderTexture(value)

--- a/src/gdext/classes/gdviewport.nim
+++ b/src/gdext/classes/gdviewport.nim
@@ -748,17 +748,17 @@ template `positionalShadowAtlasSize=`*(self: Viewport; value) = self.setPosition
 template positionalShadowAtlas16Bits*(self: Viewport): untyped = self.getPositionalShadowAtlas16Bits()
 template `positionalShadowAtlas16Bits=`*(self: Viewport; value) = self.setPositionalShadowAtlas16Bits(value)
 
-template positionalShadowAtlasQuad0*(self: Viewport): untyped = self.getPositionalShadowAtlasQuadrantSubdiv(0)
-template `positionalShadowAtlasQuad0=`*(self: Viewport; value) = self.setPositionalShadowAtlasQuadrantSubdiv(0, value)
+template positionalShadowAtlasQuad0*(self: Viewport): untyped = self.getPositionalShadowAtlasQuadrantSubdiv(int32(0))
+template `positionalShadowAtlasQuad0=`*(self: Viewport; value) = self.setPositionalShadowAtlasQuadrantSubdiv(int32(0), value)
 
-template positionalShadowAtlasQuad1*(self: Viewport): untyped = self.getPositionalShadowAtlasQuadrantSubdiv(1)
-template `positionalShadowAtlasQuad1=`*(self: Viewport; value) = self.setPositionalShadowAtlasQuadrantSubdiv(1, value)
+template positionalShadowAtlasQuad1*(self: Viewport): untyped = self.getPositionalShadowAtlasQuadrantSubdiv(int32(1))
+template `positionalShadowAtlasQuad1=`*(self: Viewport; value) = self.setPositionalShadowAtlasQuadrantSubdiv(int32(1), value)
 
-template positionalShadowAtlasQuad2*(self: Viewport): untyped = self.getPositionalShadowAtlasQuadrantSubdiv(2)
-template `positionalShadowAtlasQuad2=`*(self: Viewport; value) = self.setPositionalShadowAtlasQuadrantSubdiv(2, value)
+template positionalShadowAtlasQuad2*(self: Viewport): untyped = self.getPositionalShadowAtlasQuadrantSubdiv(int32(2))
+template `positionalShadowAtlasQuad2=`*(self: Viewport; value) = self.setPositionalShadowAtlasQuadrantSubdiv(int32(2), value)
 
-template positionalShadowAtlasQuad3*(self: Viewport): untyped = self.getPositionalShadowAtlasQuadrantSubdiv(3)
-template `positionalShadowAtlasQuad3=`*(self: Viewport; value) = self.setPositionalShadowAtlasQuadrantSubdiv(3, value)
+template positionalShadowAtlasQuad3*(self: Viewport): untyped = self.getPositionalShadowAtlasQuadrantSubdiv(int32(3))
+template `positionalShadowAtlasQuad3=`*(self: Viewport; value) = self.setPositionalShadowAtlasQuadrantSubdiv(int32(3), value)
 
 template canvasTransform*(self: Viewport): untyped = self.getCanvasTransform()
 template `canvasTransform=`*(self: Viewport; value) = self.setCanvasTransform(value)

--- a/src/gdext/classes/gdwindow.nim
+++ b/src/gdext/classes/gdwindow.nim
@@ -706,29 +706,29 @@ template `transientToFocused=`*(self: Window; value) = self.setTransientToFocuse
 template exclusive*(self: Window): untyped = self.isExclusive()
 template `exclusive=`*(self: Window; value) = self.setExclusive(value)
 
-template unresizable*(self: Window): untyped = self.getFlag(0)
-template `unresizable=`*(self: Window; value) = self.setFlag(0, value)
+template unresizable*(self: Window): untyped = self.getFlag(Window_Flags(0))
+template `unresizable=`*(self: Window; value) = self.setFlag(Window_Flags(0), value)
 
-template borderless*(self: Window): untyped = self.getFlag(1)
-template `borderless=`*(self: Window; value) = self.setFlag(1, value)
+template borderless*(self: Window): untyped = self.getFlag(Window_Flags(1))
+template `borderless=`*(self: Window; value) = self.setFlag(Window_Flags(1), value)
 
-template alwaysOnTop*(self: Window): untyped = self.getFlag(2)
-template `alwaysOnTop=`*(self: Window; value) = self.setFlag(2, value)
+template alwaysOnTop*(self: Window): untyped = self.getFlag(Window_Flags(2))
+template `alwaysOnTop=`*(self: Window; value) = self.setFlag(Window_Flags(2), value)
 
-template transparent*(self: Window): untyped = self.getFlag(3)
-template `transparent=`*(self: Window; value) = self.setFlag(3, value)
+template transparent*(self: Window): untyped = self.getFlag(Window_Flags(3))
+template `transparent=`*(self: Window; value) = self.setFlag(Window_Flags(3), value)
 
-template unfocusable*(self: Window): untyped = self.getFlag(4)
-template `unfocusable=`*(self: Window; value) = self.setFlag(4, value)
+template unfocusable*(self: Window): untyped = self.getFlag(Window_Flags(4))
+template `unfocusable=`*(self: Window; value) = self.setFlag(Window_Flags(4), value)
 
-template popupWindow*(self: Window): untyped = self.getFlag(5)
-template `popupWindow=`*(self: Window; value) = self.setFlag(5, value)
+template popupWindow*(self: Window): untyped = self.getFlag(Window_Flags(5))
+template `popupWindow=`*(self: Window; value) = self.setFlag(Window_Flags(5), value)
 
-template extendToTitle*(self: Window): untyped = self.getFlag(6)
-template `extendToTitle=`*(self: Window; value) = self.setFlag(6, value)
+template extendToTitle*(self: Window): untyped = self.getFlag(Window_Flags(6))
+template `extendToTitle=`*(self: Window; value) = self.setFlag(Window_Flags(6), value)
 
-template mousePassthrough*(self: Window): untyped = self.getFlag(7)
-template `mousePassthrough=`*(self: Window; value) = self.setFlag(7, value)
+template mousePassthrough*(self: Window): untyped = self.getFlag(Window_Flags(7))
+template `mousePassthrough=`*(self: Window; value) = self.setFlag(Window_Flags(7), value)
 
 template forceNative*(self: Window): untyped = self.getForceNative()
 template `forceNative=`*(self: Window; value) = self.setForceNative(value)

--- a/src/gdext/surface/classutils.nim
+++ b/src/gdext/surface/classutils.nim
@@ -19,7 +19,7 @@ proc instantiate_internal*[T: SomeUserClass](Type: typedesc[T]): T =
   interfaceObjectSetInstance(objectPtr, addr classname T, cast[pointer](result))
   interfaceObjectSetInstanceBinding(objectPtr, environment.library, cast[pointer](result), addr T.callbacks)
 
-proc instantiate*[T: Object](_: typedesc[T]): T =
+proc instantiate*[T: Object and not RefCounted](_: typedesc[T]): T =
   when Dev.debugCallbacks:
     echo SYNC.INSTANTIATE, $T
   result = instantiate_internal T


### PR DESCRIPTION
Fixes #125 

Fixes a problem in which properties that access with index internally cause compile errors.

Caused by passing a magic number when an enum should have been passed.

And solved by expanding to enum at the stage of generating bindings.