### PR TITLE
Feat: support to register virtual method

### DIFF
--- a/src/gdext/core/userclass/contracts.nim
+++ b/src/gdext/core/userclass/contracts.nim
@@ -7,6 +7,7 @@ type Contract*[T] = object
 var invoked* {.compileTime.} : HashSet[string]
 
 template enums*(c: typedesc[Contract]): static Event = event $c.T & "::contract::enums"
+template virtual_base*(c: typedesc[Contract]): static Event = event $c.T & "::contract::virtual-base"
 template virtual*(c: typedesc[Contract]): static Event = event $c.T & "::contract::virtual"
 template procedure*(c: typedesc[Contract]): static Event = event $c.T & "::contract::procedure"
 template pre_property*(c: typedesc[Contract]): static Event = event $c.T & "::contract::pre-property"
@@ -16,12 +17,14 @@ template signal*(c: typedesc[Contract]): static Event = event $c.T & "::contract
 
 template invoke*(contract: typedesc[Contract]) =
   proc register_enums {.expandEvent: contract.enums.}
+  proc register_virtual_base {.expandEvent: contract.virtual_base.}
   proc register_virtual {.expandEvent: contract.virtual.}
   proc register_procedure {.expandEvent: contract.procedure.}
   proc register_pre_property {.expandEvent: contract.pre_property.}
   proc register_property {.expandEvent: contract.property.}
   proc register_signal {.expandEvent: contract.signal.}
   register_enums()
+  register_virtual_base()
   register_virtual()
   register_procedure()
   register_pre_property()

--- a/src/gdext/core/userclass/virtuals.nim
+++ b/src/gdext/core/userclass/virtuals.nim
@@ -1,0 +1,61 @@
+import std/[sequtils, sets, tables, genasts]
+
+import gdext/gdinterface/[objects, extracommands, exceptions]
+
+import gdext/utils/macros
+import gdext/core/gdclass
+import gdext/core/typeshift
+
+import contracts
+import methodinfo
+
+proc emitterdef(middle: MiddleExp; procdef: NimNode): NimNode =
+  let body = ident"body"
+  let namesym = ident"methodName"
+  result = newProc(procType = nnkTemplateDef,
+    name =  ident($middle.name & "_emit").postFix("*"),
+    params = concat(@[bindsym"untyped"], procdef.params[1..^1], @[newIdentDefs(body, newEmptyNode())])
+  )
+
+  let call = genAst(
+        self = procdef.params[1][0],
+        args = newBracket middle.args.mapIt(ident"variant".newCall it.namesym),
+        namesym,
+      ):
+    self.callScriptMethod(namesym, args)
+
+  let sentence =
+    if middle.hasResult:
+      genast(call, resT = middle.result_T):
+        return call.get(resT)
+    else:
+      genast(call):
+        discard call
+        return
+
+  result.body = genAst(namesym, namelit = middle.name.toStrLit, sentence, body):
+    try:
+      let namesym {.global.} = stringName namelit
+      if self.hasScriptMethod(namesym):
+        sentence
+      else:
+        body
+    except:
+      reportErr getCurrentException()
+      return
+
+proc callwithEmitter*(procdef: NimNode): NimNode =
+  ident($procdef.name & "_emit").newCall(procdef.params[1..^1].mapIt(it[0])).add(procdef.body)
+
+proc sync_virtualDef*(procdef: NimNode): NimNode =
+  var middle = parseMiddle procdef
+
+  procdef.body = procdef.callWithEmitter()
+
+  result = quote"@" do:
+    @(middle.emitterdef(procdef))
+    @procdef
+    proc register_virtualMethod {.execon: Contract[@(middle.self_T)].virtual_base.} =
+      let info = @(middle.virtualMethodInfo)
+      interface_classdb_register_extension_class_virtual_method(
+        environment.library, addr className @(middle.self_T), addr info)

--- a/src/gdext/surface/userclass.nim
+++ b/src/gdext/surface/userclass.nim
@@ -1,15 +1,16 @@
-import std/macros
 import std/sets
 import std/tables
 
 import gdext/buildconf
-import gdext/gdinterface/[extracommands, objects, classDB]
+import gdext/gdinterface/[native, extracommands, objects, classDB]
 
+import gdext/utils/macros
+import gdext/core/builtinindex
 import gdext/core/gdclass
-
 import gdext/core/userclass/contracts
 import gdext/core/userclass/procs
 import gdext/core/userclass/signals
+import gdext/core/userclass/virtuals
 import gdext/gen/classindex
 import gdext/surface/classutils
 import gdext/surface/properties
@@ -115,7 +116,10 @@ template signal* {.pragma.}
 macro gdsync*(body): untyped =
   case body.kind
   of nnkMethodDef:
-    sync_methodDef(body)
+    if body.hasPragma("base"):
+      sync_virtualDef(body)
+    else:
+      sync_methodDef(body)
   of nnkProcDef, nnkConverterDef, nnkFuncDef:
     if body.isSignal:
       sync_signal(body)

--- a/testproject/runtime/inherited_node01.gd
+++ b/testproject/runtime/inherited_node01.gd
@@ -1,0 +1,4 @@
+extends VirtualNode01
+
+func virtualMethod(str: String) -> String:
+  return "virtualMethod of InheritedNode01 is called " + str

--- a/testproject/runtime/inherited_node02.gd
+++ b/testproject/runtime/inherited_node02.gd
@@ -1,0 +1,4 @@
+extends VirtualNode02
+
+func virtualMethod(str: String) -> String:
+  return "virtualMethod of InheritedNode02 is called " + str

--- a/testproject/runtime/main.gd
+++ b/testproject/runtime/main.gd
@@ -9,6 +9,7 @@ var signal_arg1_executed = false
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	test_func()
+	test_virtual_func()
 	test_grobal_func()
 	exit_with_status()
 
@@ -31,6 +32,14 @@ func test_func():
 	assert_equal(node.varargs_concrete(1, 2, 3, 4, 5), "1, 2, 3, 4, 5")
 
 	assert_equal(node.most_complex("a", "b", "c", "d", "e", "f", "g"), "a b c d e f g")
+
+func test_virtual_func():
+	# $VirtualNode01.virtualMethod()
+	assert_equal($InheritedNode01.virtualMethod("from GDScript"),
+    "virtualMethod of InheritedNode01 is called from GDScript")
+	# $VirtualNode02.virtualMethod()
+	assert_equal($InheritedNode02.virtualMethod("from GDScript"),
+    "virtualMethod of InheritedNode02 is called from GDScript")
 
 func test_grobal_func():
 	NimMain.signal_arg0.connect(_on_nim_signal_arg0)

--- a/testproject/runtime/main.tscn
+++ b/testproject/runtime/main.tscn
@@ -1,7 +1,9 @@
-[gd_scene load_steps=3 format=3 uid="uid://dyswbjsdvglbr"]
+[gd_scene load_steps=5 format=3 uid="uid://dyswbjsdvglbr"]
 
 [ext_resource type="Script" path="res://main.gd" id="1_x2b6x"]
 [ext_resource type="Texture2D" uid="uid://b5lc5myy1blsf" path="res://icon.png" id="2_x3ep8"]
+[ext_resource type="Script" path="res://inherited_node01.gd" id="3_6ul88"]
+[ext_resource type="Script" path="res://inherited_node02.gd" id="4_lmn8h"]
 
 [node name="Main" type="Node"]
 script = ExtResource("1_x2b6x")
@@ -10,3 +12,13 @@ script = ExtResource("1_x2b6x")
 
 [node name="Sprite2D" type="Sprite2D" parent="GDExtNode"]
 texture = ExtResource("2_x3ep8")
+
+[node name="VirtualNode01" type="VirtualNode01" parent="."]
+
+[node name="InheritedNode01" type="VirtualNode01" parent="."]
+script = ExtResource("3_6ul88")
+
+[node name="VirtualNode02" type="VirtualNode02" parent="."]
+
+[node name="InheritedNode02" type="VirtualNode02" parent="."]
+script = ExtResource("4_lmn8h")

--- a/testproject/runtime/nim/bootstrap.nim
+++ b/testproject/runtime/nim/bootstrap.nim
@@ -10,6 +10,8 @@ import cases/enums
 import cases/image
 import cases/issues
 import classes/gdextnode
+import classes/gdvirtualnode01
+import classes/gdvirtualnode02
 import classes/gdtestobject
 
 # ==================================
@@ -18,6 +20,8 @@ proc register_classes {.execon: initialize_scene.} =
   # register your extension classes here
   # register MyClass
   register GDExtNode
+  register VirtualNode01
+  register VirtualNode02
   register TestObject
 
   # ====================================

--- a/testproject/runtime/nim/src/classes/gdextnode/typedef.nim
+++ b/testproject/runtime/nim/src/classes/gdextnode/typedef.nim
@@ -5,6 +5,8 @@ import gdext
 import gdext/gdinterface/native
 import gdext/core/[gdclass, typeshift]
 
+import classes/gdvirtualnode01
+
 # sugar of `import godot/classDetail/classDetail_native_T`
 # Since this library is still early stage, we recommend to use this sugar for portability
 import gdext/classes/[
@@ -140,6 +142,18 @@ proc test_FirstClassFunction(self: GDExtNode) =
       check listen_0_result[1]
       check listen_1_result[1] == "SIGNAL"
 
+proc test_VirtualMethod(self: GDExtNode) =
+  suite "virtuals":
+    test "call virtual method from nim source":
+      check (self/"../VirtualNode01" as VirtualNode01).virtualMethod("from Nim Source") ==
+        "virtualMethod of VirtualNode01 is called from Nim Source"
+      check (self/"../InheritedNode01" as VirtualNode01).virtualMethod("from Nim Source") ==
+        "virtualMethod of InheritedNode01 is called from Nim Source"
+      check (self/"../VirtualNode02" as VirtualNode01).virtualMethod("from Nim Source") ==
+        "virtualMethod of VirtualNode02 is called from Nim Source"
+      check (self/"../InheritedNode02" as VirtualNode01).virtualMethod("from Nim Source") ==
+        "virtualMethod of InheritedNode02 is called from Nim Source"
+
 # Using `method` to override virtual functions of Engine-Class.
 # No specific pragma is needed.
 # based on Node.ready()
@@ -151,3 +165,4 @@ method ready(self: GDExtNode) {.gdsync.} =
     self.test_Node()
     self.test_Resource()
     self.test_FirstclassFunction()
+    self.test_VirtualMethod()

--- a/testproject/runtime/nim/src/classes/gdvirtualnode01.nim
+++ b/testproject/runtime/nim/src/classes/gdvirtualnode01.nim
@@ -1,0 +1,14 @@
+import gdext
+
+type VirtualNode01* = ptr object of Node
+
+
+method virtualMethod*(self: VirtualNode01; str: string): string {.gdsync, base.} =
+  "virtualMethod of VirtualNode01 is called " & str
+
+method virtualMethod2*(self: VirtualNode01) {.gdsync, base.} =
+  discard
+method virtualMethod3*(self: VirtualNode01; value: int): int {.gdsync, base.} =
+  result = value
+method virtualMethod4*(self: VirtualNode01; value: int): int {.gdsync, base.} =
+  return value

--- a/testproject/runtime/nim/src/classes/gdvirtualnode02.nim
+++ b/testproject/runtime/nim/src/classes/gdvirtualnode02.nim
@@ -1,0 +1,9 @@
+import gdext
+import gdext/classes/gdNode
+
+import classes/gdvirtualnode01
+
+type VirtualNode02* = ptr object of VirtualNode01
+
+method virtualMethod*(self: VirtualNode02; str: string): string {.gdsync.} =
+  "virtualMethod of VirtualNode02 is called " & str


### PR DESCRIPTION
Support the definition of new virtual functions and the invocation of overridden virtual functions in GDScript.

The following operations are **not** supported:

* Calling virtual functions defined in Nim from GDScript without overriding them in itself

### Usage:

Register the base method with Godot by marking the method with the {.gdsync, base.} pragma.
Default behavior can be set for virtual functions.

https://github.com/godot-nim/gdext-nim/blob/15331967c3fabd410e7d2f2c86df716b56cac24b/testproject/runtime/nim/src/classes/gdvirtualnode01.nim#L1-L7

Override as well as engine built-in methods such as ready.

https://github.com/godot-nim/gdext-nim/blob/15331967c3fabd410e7d2f2c86df716b56cac24b/testproject/runtime/nim/src/classes/gdvirtualnode02.nim#L1-L9

The name you define will be published in the GDScript as is. A way to alias this has not yet been implemented.

https://github.com/godot-nim/gdext-nim/blob/15331967c3fabd410e7d2f2c86df716b56cac24b/testproject/runtime/inherited_node01.gd#L1-L4
https://github.com/godot-nim/gdext-nim/blob/15331967c3fabd410e7d2f2c86df716b56cac24b/testproject/runtime/inherited_node01.gd#L1-L4

Virtual function calls can be made in the same way as in the Nim standard.
If overridden, the process is executed; otherwise, the default process is executed.

https://github.com/godot-nim/gdext-nim/blob/15331967c3fabd410e7d2f2c86df716b56cac24b/testproject/runtime/nim/src/classes/gdextnode/typedef.nim#L145-L155
