### PR TITLE
Fix(internal): allocate property info

### DIFF
--- a/src/gdext/core/gdclass.nim
+++ b/src/gdext/core/gdclass.nim
@@ -3,6 +3,7 @@ import std/[tables, typetraits]
 import gdext/buildconf
 
 import gdext/gdinterface/[native, extracommands]
+import gdext/gen/globalenums
 import gdext/utils/macros
 
 import gdext/core/builtinindex
@@ -26,7 +27,14 @@ type
     when Dev.debugCallbacks:
       name*: string
 
-type
+  HeapPropertyInfo* = object
+    `type`*: VariantType
+    name*: ref StringName
+    className*: ref Stringname
+    hint*: PropertyHint
+    hintString*: ref String
+    usage*: set[PropertyUsageFlags]
+
   Object* = ptr object of RootObj
     control: ObjectControl
   RefCounted* = ptr object of Object

--- a/src/gdext/core/userclass/methodinfo.nim
+++ b/src/gdext/core/userclass/methodinfo.nim
@@ -50,13 +50,13 @@ template hasResult*(middle: MiddleExp): bool = middle.result_T != nil
 proc returnValue(middle: MiddleExp): NimNode =
   if middle.hasResult:
     quote("@") do:
-      propertyInfo(typedesc @(middle.result_T))
+      propertyInfo(typedesc @(middle.result_T)).unheap
   else:
     quote("@") do:
-      propertyInfo(VariantType_Nil)
+      propertyInfo(VariantType_Nil).unheap
 proc returnValueInfo(middle: MiddleExp): NimNode =
   quote("@") do:
-    propertyInfo(typedesc @(middle.result_T))
+    propertyInfo(typedesc @(middle.result_T)).unheap
 proc returnValueMeta(middle: MiddleExp): NimNode =
   quote("@") do:
     metadata(typedesc @(middle.result_T))
@@ -65,7 +65,7 @@ proc argumentsInfo(middle: MiddleExp): NimNode =
   result = newNimNode nnkBracket
   for (name, Type, default) in middle.args:
     result.add quote("@") do:
-      propertyInfo(typedesc @Type, stringName @(name.toStrLit))
+      propertyInfo(typedesc @Type, stringName @(name.toStrLit)).unheap
 
 proc argumentsMeta(middle: MiddleExp): NimNode =
   result = newNimNode nnkBracket

--- a/src/gdext/core/userclass/propertyinfo.nim
+++ b/src/gdext/core/userclass/propertyinfo.nim
@@ -90,27 +90,39 @@ proc defaultUnit*[S: SomeFloatProperty](_: typedesc[S]): float =
   0.001
 proc defaultUnit*[S: SomeIntProperty](_: typedesc[S]): int = 1
 
+proc unheap*(info: HeapPropertyInfo): PropertyInfo =
+  cast[ptr PropertyInfo](addr info)[]
+
+proc new(x: String): ref String =
+  new result
+  result[] = x
+proc new(x: StringName): ref StringName =
+  new result
+  result[] = x
+
+
 proc propertyInfo*(typ: VariantType;
       name: StringName = StringName.empty;
       class_name: StringName = StringName.empty;
       hint: PropertyHint = propertyHint_None;
       hint_string: String = String.empty;
       usage: system.set[PropertyUsageFlags] = PropertyUsageFlags.propertyUsageDefault;
-    ): PropertyInfo =
-  PropertyInfo(
+    ): HeapPropertyInfo =
+  HeapPropertyInfo(
     type: typ,
-    name: addr name,
-    class_name: addr class_name,
-    hint: uint32 hint,
-    hint_string: addr hint_string,
-    usage: cast[uint32](usage),
+    name: new name,
+    class_name: new class_name,
+    hint: hint,
+    hint_string: new hint_string,
+    usage: usage,
   )
+
 proc propertyInfo*[T: SomeProperty](_: typedesc[T];
       name: StringName = StringName.empty;
       hint: PropertyHint = propertyHint_None;
       hint_string: String = String.empty;
       usage: system.set[PropertyUsageFlags] = PropertyUsageFlags.propertyUsageDefault;
-    ): PropertyInfo =
+    ): HeapPropertyInfo =
   propertyInfo(
     T.variantType,
     name,
@@ -135,5 +147,5 @@ proc propertyInfo*[T: SomeProperty](_: typedesc[varargs[T]];
       hint: PropertyHint = propertyHint_None;
       hint_string: String = String.empty;
       usage: system.set[PropertyUsageFlags] = PropertyUsageFlags.propertyUsageDefault;
-    ): PropertyInfo =
+    ): HeapPropertyInfo =
   propertyInfo(typedesc T, name, hint, hint_string, usage)

--- a/src/gdext/core/userclass/signals.nim
+++ b/src/gdext/core/userclass/signals.nim
@@ -37,7 +37,7 @@ macro parseParams (params): untyped =
     if i == 0: continue
     let namelit = name.toStrLit
     arguments.add quote do:
-      propertyInfo(typedesc `typ`, stringName `namelit`)
+      propertyInfo(typedesc `typ`, stringName `namelit`).unheap
 
   quote do: @`arguments`
 

--- a/src/gdext/surface/properties.nim
+++ b/src/gdext/surface/properties.nim
@@ -34,12 +34,12 @@ var propertyStage {.compileTime.}: PropertyStage = PropertyStage.property
 import gdext/gen/[globalenums, builtinclasses, classindex]
 
 proc register_property_internal*(
-      info: PropertyInfo;
+      info: HeapPropertyInfo;
       typ: StringName;
       getter: StringName = StringName.empty;
       setter: StringName = StringName.empty;
     ) =
-  classDB.registerProperty(typ, addr info, setter, getter)
+  classDB.registerProperty(typ, cast[ptr PropertyInfo](addr info), setter, getter)
 
 macro strlit(x): string = newlit $x
 


### PR DESCRIPTION
Until now, PropertyInfo has been created in the stack area, but we have found that if we need to use the PropertyInfo we have created around, there is a potential problem with it being destroyed once it leaves the scope.

This PR does not fix the specific bug that is happening now, but is a change for the future.