### PR TITLE
Refactor: improve signal/proc-generation's readability

### DIFF
--- a/src/gdext/core/userclass/procs.nim
+++ b/src/gdext/core/userclass/procs.nim
@@ -1,71 +1,57 @@
-import gdext/utils/macros
 import std/[sequtils, strutils, sets, tables]
+
+import gdext/buildconf
+import gdext/utils/macros
 
 import gdext/gdinterface/classDB
 import gdext/core/gdclass
 
+import tools
 import contracts
 import methodinfo
-import propertyinfo
 import virtuals
 
 const errmsgSelfTypeMismatch = "invalid form; In order to synchronize the function, the first argument must inherit from the class provided by gdext."
-
-proc withCorrectClassMethodForm(node, stmt: NimNode): NimNode =
-  let arg0T = node.params[1][1]
-  result = newNimNode nnkWhenStmt
-
-  if node.kind == nnkMethodDef:
-    result.add newElifBranch(
-      (quote do: `arg0T` isnot SomeClass),
-      bindsym"lineerror".newcall(newlit errmsgSelfTypeMismatch, node.params[1])
-    )
-
-  for i, arg in node.params:
-    if i == 0: continue
-    let argT = arg[1]
-    result.add newElifBranch(
-      (quote do: `argT` isnot SomeProperty),
-      bindsym"lineerror".newcall(newlit "invalid form; the type `" & argT.repr & "` is not supported for argument.", arg)
-    )
-
-  result.add newElse(stmt)
 
 macro registerProc*(procdef): untyped =
   let procdef =
     if procdef.kind == nnkProcDef: procdef
     else: procdef.getImpl
-  let arg0_T = procdef.params[1][1]
+  let Self = procdef.params[1][1]
 
   let gdname = procdef.getPragmaVal("name") or newLit $procdef.name
 
   let methodinfoDef = procdef.classMethodInfo(gdname)
 
   quote do:
-    proc `gdname` {.execon: Contract[typedesc[`arg0T`]].procedure.} =
+    proc `gdname` {.execon: Contract[typedesc[`Self`]].procedure.} =
       let info = `methodinfoDef`
-      classDB.registerMethod(className(typedesc `arg0_T`), addr info)
+      classDB.registerMethod(className(typedesc `Self`), addr info)
 
 proc makeNimMainProc(procdef: NimNode): NimNode =
   newProc(
     name = ident $procdef.name,
     params = concat(
-      @[procdef.params[0]],
-      @[newIdentDefs(ident"_", bindsym"typeof".newcall(ident"extmain"))],
+      @[procdef.params[0],
+        newIdentDefs(ident"_", bindsym"typeof".newcall(ident"extmain"))],
       procdef.params[1..^1]),
     pragmas = procdef.pragma,
     body = procdef.name.newCall(procdef.params[1..^1].mapIt(it[0])),
     procType = procdef.kind,
   )
 
-proc sync_procDef*(procdef: NimNode): NimNode =
+macro syncProcGlobal*(procdef): untyped =
   let procNimMain = makeNimMainProc procdef
-  if procdef.params.len <= 1:
-    return quote do:
-      `procdef`
-      `procNimMain`
-      registerProc `procNimMain`
 
+  if Extension.name in invoked:
+    error "Registration is already finished. Define it before `GDExtensionEntryPoint` appears.", procdef
+
+  quote do:
+    `procdef`
+    `procNimMain`
+    registerProc `procNimMain`
+
+macro syncProcLocal*(procdef): untyped =
   let arg0T = procdef.params[1][1]
 
   let arg0Tsym =
@@ -73,42 +59,23 @@ proc sync_procDef*(procdef: NimNode): NimNode =
     else: arg0T
 
   if arg0Tsym.repr in invoked:
-    error "Registration is not reflected. Define it before calling proc register " & arg0Tsym.repr & ".", procdef
+    error "Registration is already finished. Define it before `register " & arg0Tsym.repr & "` appears.", procdef
 
-  result = newNimNode nnkWhenStmt
+  quote do:
+    `procdef`
+    registerProc `procdef`
 
-  var varargsFound: bool
-  for i, (name, typ, default) in procdef.params.breakArgs:
-    if varargsFound:
-      error "invalid form; varargs must be placed at last.", typ
-    var argT =
-      if typ.kind == nnkEmpty: ident"typeof".newCall(default)
-      else: typ
-    if argT.isVarargs:
-      varargsFound = true
-      argT = argT[1]
-    result.add newElifBranch(
-      (quote do: `argT` isnot SomeProperty),
-      bindsym"lineerror".newcall(newlit "invalid form; the type `" & argT.repr & "` is not supported for argument.", name)
-    )
+proc sync_procDef*(procdef: NimNode): NimNode =
+  if procdef.params.len <= 1:
+    return bindSym"syncProcGlobal".newCall procdef
 
-  result.add newElifBranch(
-    quote do:
-      `arg0T` is SomeClass,
-    quote do:
-      `procdef`
-      registerProc `procdef`
-  )
+  procdef.withCheckTypes(
+    onSelfTypeFailed = bindSym"syncProcGlobal".newCall procdef,
+    onDefault = bindSym"syncProcLocal".newCall procdef)
 
-
-  result.add newElse(
-    quote do:
-      `procdef`
-      `procNimMain`
-      registerProc `procNimMain`
-  )
 
 proc sync_methodDef*(body: Nimnode): NimNode =
+  let lineerror = bindSym "lineerror"
   let methoddef = body
   # for sym in bindsym(methoddef[0], brForceOpen):
   #   hint repr sym.getImpl, body
@@ -124,10 +91,14 @@ proc sync_methodDef*(body: Nimnode): NimNode =
   let methoddefWithEmit = methoddef.copy
   methoddefWithEmit.body = methoddef.callWithEmitter
 
-  result = methoddef.withCorrectClassMethodForm quote do:
-    when `selfT`.vmap.hasKey(`methodStrlit`):
-      `methoddef`
-      proc `procsym` {.execon: Contract[`selfT`].virtual.} =
-        vmethods(`selfT`)[stringName `selfT`.vmap[`methodstrlit`]] = `selfT`.`methodname`
-    else:
-      `methoddefWithEmit`
+  result = methoddef.withCheckTypes(
+    onSelfTypeFailed =
+      lineerror.newcall(newlit errmsgSelfTypeMismatch, body),
+    onDefault = (quote do:
+      when `selfT`.vmap.hasKey(`methodStrlit`): # overriding built-in method
+        `methoddef`
+        proc `procsym` {.execon: Contract[`selfT`].virtual.} =
+          vmethods(`selfT`)[stringName `selfT`.vmap[`methodstrlit`]] = `selfT`.`methodname`
+      else: # overriding user-defined method
+        `methoddefWithEmit`
+    ))

--- a/src/gdext/core/userclass/tools.nim
+++ b/src/gdext/core/userclass/tools.nim
@@ -1,0 +1,33 @@
+import std/[sequtils]
+
+import gdext/utils/macros
+import gdext/core/gdclass
+import propertyinfo
+
+proc withCheckTypes*(node, onSelfTypeFailed, onDefault: NimNode): NimNode =
+  let lineerror = bindSym "lineerror"
+  result = newNimNode nnkWhenStmt
+
+  if node.hasReturn:
+    let arg = node.params[0]
+    result.add newElifBranch( (quote do: `arg` isnot SomeProperty),
+      lineerror.newcall(newlit "invalid form; the type `" & arg.repr & "` is not supported for result.", arg)
+    )
+
+  let args = node.params.breakArgs.toSeq
+  for (i, arg) in args:
+    var argT = arg.Type or bindSym"typeof".newCall arg.default
+    if argT.isVarargs:
+      if i != args.high:
+        error "invalid form; varargs must be placed at last.", arg.name
+      else:
+        argT = argT[1]
+    result.add newElifBranch( (quote do: `argT` isnot SomeProperty),
+      lineerror.newcall(newlit "invalid form; the type `" & argT.repr & "` is not supported for argument.", arg.name)
+    )
+
+  let Self = node.params[1][1]
+  result.add newElifBranch( (quote do: `Self` isnot SomeUserClass),
+    onSelfTypeFailed)
+
+  result.add newElse(onDefault)


### PR DESCRIPTION
Organize function synchronization macros that had become spaghetti.

There are no changes in functionality.