### PR TITLE
Feat: printRich(varargs)

### DIFF
--- a/src/gdext.nim
+++ b/src/gdext.nim
@@ -35,3 +35,7 @@ export gdextensionmain.ExtensionMain, gdextensionmain.extmain
 proc print*(args: varargs[Variant, variant]) =
   if unlikely(args.len == 0): return
   utilityfuncs.print(args[0], args[1..^1])
+
+proc printRich*(args: varargs[Variant, variant]) =
+  if unlikely(args.len == 0): return
+  utilityfuncs.printRich(args[0], args[1..^1])


### PR DESCRIPTION
Like the print function, the printRich function is overloaded to allow arbitrary arguments (convertible to Variant) to be passed.