### PR TITLE
Feat: gdsync for TypeDef. That will register the class implicitly.

### DIFF
--- a/src/gdext/surface/init.nim
+++ b/src/gdext/surface/init.nim
@@ -43,13 +43,17 @@ template GDExtension_EntryPoint*: untyped =
     # almost all uses is to register user-defined classes
     of Initialization_Core:
       exec_initialize_core()
+      registerImplicitly(Initialization_Core)
     of Initialization_Servers:
       exec_initialize_servers()
+      registerImplicitly(Initialization_Servers)
     of Initialization_Scene:
       initializeExtensionMain()
       exec_initialize_scene()
+      registerImplicitly(Initialization_Scene)
     of Initialization_Editor:
       exec_initialize_editor()
+      registerImplicitly(Initialization_Editor)
       const loadedClasses = contracts.invoked.len
       gLoaded = loadedClasses
       {.emit: "NimMain();".}

--- a/src/gdext/wizard/subcommands/extension.nim
+++ b/src/gdext/wizard/subcommands/extension.nim
@@ -9,6 +9,7 @@ const
   `.gitignore` = staticRead templateroot/".gitignore"
   `bootstrap.nim` = staticRead templateroot/"bootstrap.nim"
   `config.nims` = staticRead templateroot/"config.nims"
+  `gdmyclass.nim` = staticRead templateroot/"src/classes/gdmyclass.nim"
 
 proc new_extension*(name = default Directory): 0..1 =
   var cli = CliContext(wizard: "wizard new-extension*")
@@ -30,13 +31,14 @@ proc new_extension*(name = default Directory): 0..1 =
   let symbols = @[
     ("$name", extension)
   ]
+  createDir extensionPath/"src/classes"
 
   writeFileWithDialog(extensionPath/extension & ".gdextension", `.gdextension`.multiReplace(symbols))
   writeFileWithDialog(extensionPath/".gitignore", `.gitignore`.multiReplace(symbols))
   writeFileWithDialog(extensionPath/"config.nims", `config.nims`.multiReplace(symbols))
   writeFileWithDialog(extensionPath/"bootstrap.nim", `bootstrap.nim`.multiReplace(symbols))
+  writeFileWithDialog(extensionPath/"src/classes/gdmyclass.nim", `gdmyclass.nim`.multiReplace(symbols))
 
-  createDir extensionPath/"src"
 
 proc dispatch_new_extension*(opt: var OptParser) =
   next opt

--- a/src/gdext/wizard/subcommands/extension/template/bootstrap.nim
+++ b/src/gdext/wizard/subcommands/extension/template/bootstrap.nim
@@ -1,16 +1,5 @@
 import gdext
-
-# import your extension classes here
-# import myclass
-
-# ==================================
-
-proc register_classes {.execon: initialize_scene.} =
-  # register your extension classes here
-  # register MyClass
-
-  # ====================================
-  discard
+import classes/gdMyClass
 
 
 GDExtensionEntryPoint

--- a/src/gdext/wizard/subcommands/extension/template/src/classes/gdmyclass.nim
+++ b/src/gdext/wizard/subcommands/extension/template/src/classes/gdmyclass.nim
@@ -1,0 +1,37 @@
+import gdext
+import gdext/classes/gdNode
+
+import std/strutils
+
+type MyClass* {.gdsync.} = ptr object of Node
+  # {.gdexport.} to publish the property to editor. Do not forget to export it with `*`.
+  message* {.gdexport.}: string = "This is MyClass."
+  address: uint64
+
+# {.name.} enables to override the function name visible from the editor.
+proc address_readable(self: MyClass): string {.gdsync, name: "get_address_readable".} =
+  self.address.toHex.insertSep(' ', 4)
+
+# If you need to customize the getter/setter of property, same-name macros of the pragma is available.
+# gdsync'ed procs or lambdas are allowed for getter/setter.
+gdexport "address_readable",
+  address_readable,
+  proc (self: MyClass; value: string) = (discard)
+
+# {.gdsync, signal.} enables to define signal. Note that the return type must be Error.
+proc mySignal(self: MyClass): Error {.gdsync, signal.}
+
+proc myCallable(self: MyClass) {.gdsync.} =
+  printRich self.message, " It's allocated at [b]", self.address_readable, "[/b]."
+
+# onInit is like a constructor. That is called at the class is created.
+# This is not a part of GDExtension so, gdsync is not required.
+method onInit(self: MyClass) =
+  self.address = cast[uint64](self)
+
+method ready(self: MyClass) {.gdsync.} =
+  assert self.connect("mySignal", self.callable "myCallable") == ok
+  assert self.mySignal() == ok
+
+method process(self: MyClass; delta: float) {.gdsync.} =
+  discard


### PR DESCRIPTION
Allow {.gdsync.} to be passed when defining extended classes.
Classes that are {.gdsync.} are implicitly registered with the engine.
As a byproduct, the register_classes function can be removed from bootstrap.nim.
The traditional registration mechanism is still available.

Example:
```nim
# bootstrap.nim
import gdext

type MyClass* {.gdsync.} = ptr object of Node

GDExtensionEntryPoint
```