### PR TITLE
Feat: Variable-width encoding

### DIFF
--- a/src/gdext/gdinterface/extracommands.nim
+++ b/src/gdext/gdinterface/extracommands.nim
@@ -7,20 +7,22 @@ var newStringFromStringName: PtrConstructor
 var String_length: PtrBuiltinMethod
 
 proc gdstring*(str: string): String =
-  interfaceStringNewWithLatin1Chars(addr result, cstring str)
+  interfaceStringNewWithUtf8Chars(addr result, cstring str)
 proc gdstring(sn: StringName): String =
   let args = [cast[pointer](addr sn)]
   newStringFromStringName(addr result, addr args[0])
 proc length(s: String): Int =
   String_length(addr s, nil, addr result, 0)
 proc `$`*(s: String): string =
+  var buffer {.global.}: string
   let length = s.length
-  result = newString(length)
-  discard interfaceStringToLatin1Chars(addr s, cstring result, length)
+  if buffer.len < length * 6: buffer.setlen(length*6)
+  let actualSize = interfaceStringToUtf8Chars(addr s, cstring buffer, buffer.len)
+  buffer[0..<actualSize]
 proc `$`*(s: StringName): string = $gdstring s
 
 proc stringName*(str: string): StringName =
-  interfaceStringNameNewWithLatin1Chars(addr result, cstring str, false)
+  interfaceStringNameNewWithUtf8Chars(addr result, cstring str)
 
 proc className*(o: ObjectPtr): string =
   var sn: StringName

--- a/testproject/runtime/nim/src/cases/primitives.nim
+++ b/testproject/runtime/nim/src/cases/primitives.nim
@@ -1,7 +1,6 @@
 import gdext
 import testutils
-import std/unittest
-unittest.disableParamFiltering()
+import std/unicode
 
 runtime: suite "TypedArray":
   test "construct":
@@ -56,3 +55,13 @@ runtime: suite "String":
   test "to nim-string":
     let gdstr: String = "String"
     check $gdstr == "String"
+
+  test "Variable-width encoding":
+    let ja_raw: string = "これは日本語です。"
+    let en_raw: string = "This is English."
+    let ja: String = ja_raw
+    let en: String = en_raw
+    for (str, Str) in [(ja_raw, ja), (en_raw, en)]:
+      check str == $Str
+      for i, rune in str.toRunes:
+        check rune == Str[i]


### PR DESCRIPTION
Fixes a bug that caused garbled characters when strings containing multibyte characters such as Japanese and Chinese are converted to Godot.String, enabling multilingual support.

As a byproduct, String can be treated like seq[unicode.Rune].
Although it is necessary to import std/unicode separately, Rune can be obtained by iterating over the String, so Kanji characters, etc., can be correctly processed one by one.