### PR TITLE
Fix: Ignore {.gdsync.} appended to the forward declaration.

### DIFF
--- a/src/gdext/surface/userclass.nim
+++ b/src/gdext/surface/userclass.nim
@@ -134,13 +134,19 @@ proc toLevel(node: NimNode): InitializationLevel =
 macro gdsync*(body): untyped =
   case body.kind
   of nnkMethodDef:
-    if body.hasPragma("base"):
+    if body.body.kind == nnkEmpty: # forward declaration
+      hint "{.gdsync.} is not required for forward declarations.", body
+      body
+    elif body.hasPragma("base"):
       sync_virtualDef(body)
     else:
       sync_methodDef(body)
   of nnkProcDef, nnkConverterDef, nnkFuncDef:
     if body.isSignal:
       sync_signal(body)
+    elif body.body.kind == nnkEmpty: # forward declaration
+      hint "{.gdsync.} is not required for forward declarations.", body
+      body
     else:
       sync_procDef(body)
   of nnkTypeDef:

--- a/testproject/runtime/nim/src/classes/gdextnode/functions.nim
+++ b/testproject/runtime/nim/src/classes/gdextnode/functions.nim
@@ -6,6 +6,9 @@ var
   arg0_noret_result: string
   arg1_noret_result: string
 
+# {.gdsync.} for forward declaration should be ignored.
+proc arg0_noret(self: GDExtNode) {.gdsync.}
+
 proc arg0_noret(self: GDExtNode) {.gdsync.} =
   arg0_noret_result = "arg0_noret()"
 


### PR DESCRIPTION
Fixes a bug that when {.gdsync.} is added to a forward declaration, it is interpreted as an actual function declaration and the registration process is duplicated.

If {.gdsync.} is appended to the forward declaration, this pragma is ignored and a hint is output instead.