### PR TITLE
Feat: set[enum] for properties

### DIFF
--- a/src/gdext/core/typeshift.nim
+++ b/src/gdext/core/typeshift.nim
@@ -74,6 +74,7 @@ template variantType*(Type: typedesc[AltInt]): Variant_Type = VariantType_Int
 template variantType*(Type: typedesc[AltFloat]): Variant_Type = VariantType_Float
 template variantType*(Type: typedesc[AltString]): Variant_Type = VariantType_String
 template variantType*(Type: typedesc[enum]): Variant_Type = VariantType_Int
+template variantType*[E: enum](Type: typedesc[set[E]]): Variant_Type = VariantType_Int
 
 template variantType*(Type: typedesc[ptr Variant]): Variant_Type = VariantType_Nil
 

--- a/src/gdext/core/userclass/propertyinfo.nim
+++ b/src/gdext/core/userclass/propertyinfo.nim
@@ -46,6 +46,16 @@ template metadata*(T: typedesc[enum]): ClassMethodArgumentMetadata =
   else:
     MethodArgumentMetadata_Int_is_Uint64
 
+template metadata*[E: enum](T: typedesc[set[E]]): ClassMethodArgumentMetadata =
+  when sizeof(T) <= 1:
+    MethodArgumentMetadata_Int_is_Uint8
+  elif sizeof(T) <= 2:
+    MethodArgumentMetadata_Int_is_Uint16
+  elif sizeof(T) <= 4:
+    MethodArgumentMetadata_Int_is_Uint32
+  else:
+    MethodArgumentMetadata_Int_is_Uint64
+
 # Int
 # ---
 template metadata*(T: typedesc[int]): ClassMethodArgumentMetadata =
@@ -76,6 +86,7 @@ template metadata*(T: typedesc[float32]): ClassMethodArgumentMetadata = MethodAr
 template uniqueUsage*(T: typedesc): set[PropertyUsageFlags] = {}
 template uniqueUsage*(T: typedesc[Variant]): set[PropertyUsageFlags] = {propertyUsageNilIsVariant}
 template uniqueUsage*(T: typedesc[enum]): set[PropertyUsageFlags] = {propertyUsageClassIsEnum}
+template uniqueUsage*[E: enum](T: typedesc[set[E]]): set[PropertyUsageFlags] = {propertyUsageClassIsBitfield}
 
 type SomeProperty* = concept type t
   t.variantType is VariantType

--- a/testproject/runtime/main.gd
+++ b/testproject/runtime/main.gd
@@ -64,6 +64,14 @@ func test_enum():
 	assert_equal(node.test_enum_b, GDExtNode.EnumB3)
 	assert_equal(node.echoVector2Axis(Vector2.AXIS_X), Vector2.AXIS_X)
 
+	assert_equal(node.echoTestFlags(GDExtNode.Flag1), GDExtNode.Flag1)
+	assert_equal(node.echoTestFlags(GDExtNode.Flag2 | GDExtNode.Flag4), GDExtNode.Flag2 | GDExtNode.Flag4)
+	assert_equal(node.test_flags, GDExtNode.Flag2)
+	node.test_flags = GDExtNode.Flag3
+	assert_equal(node.test_flags, GDExtNode.Flag3)
+	node.test_flags = GDExtNode.Flag1 | GDExtNode.Flag4
+	assert_equal(node.test_flags, GDExtNode.Flag1 | GDExtNode.Flag4)
+
 func _on_nim_signal_arg0():
 	signal_arg0_executed = true
 func _on_nim_signal_arg1(what):

--- a/testproject/runtime/nim/src/classes/gdextnode/enums.nim
+++ b/testproject/runtime/nim/src/classes/gdextnode/enums.nim
@@ -14,12 +14,21 @@ type TestEnumB = enum
   EnumB2
   EnumB3 = (4, "ENUM!")
 
+type TestFlags = enum
+  Flag1
+  Flag2
+  Flag3
+  Flag4
+  Flag5
+
 
 GDExtNode.registerEnum TestEnumA
 GDExtNode.registerEnum TestEnumB
+GDExtNode.registerBitField TestFlags
 
 var testEnumA: TestEnumA = EnumA2
 var testEnumB: TestEnumB = EnumB2
+var testFlags: set[TestFlags] = {Flag2}
 
 gdexport "test_enum_a",
   proc(x: GDExtNode): TestEnumA = testEnumA,
@@ -29,6 +38,11 @@ gdexport "test_enum_b",
   proc(x: GDExtNode): TestEnumB = testEnumB,
   proc(x: GDExtNode; value: TestEnumB) = testEnumB = value
 
+gdexport "test_flags",
+  proc(x: GDExtNode): set[TestFlags] = testFlags,
+  proc(x: GDExtNode; value: set[TestFlags]) = testFlags = value
+
 proc echoTestEnumA(self: GDextNode; x: TestEnumA): TestEnumA {.gdsync.} = x
 proc echoTestEnumB(self: GDextNode; x: TestEnumB): TestEnumB {.gdsync.} = x
+proc echoTestFlags(self: GDextNode; x: set[TestFlags]): set[TestFlags] {.gdsync.} = x
 proc echoVector2Axis(self: GDextNode; x: Vector2_Axis): Vector2_Axis {.gdsync.} = x


### PR DESCRIPTION
set[enum] is now available as a property, argument, and return value. From the editor (as with enum), it is treated as an Int value with a name.