### PR TITLE
Destructive: Change `registerEnum/BitField(enum)` to `bind(enum/set[enum])`

### DIFF
--- a/testproject/editor/nim/src/classes/gdproptestnode.nim
+++ b/testproject/editor/nim/src/classes/gdproptestnode.nim
@@ -51,7 +51,7 @@ gdexport "icon",
   proc (self: PropTestNode): gdref Texture2D = self.icon,
   proc (self: PropTestNode; value: gdref Texture2D) = self.icon = value
 
-PropTestNode.registerEnum PropTestEnum
+PropTestNode.bind PropTestEnum
 
 gdexport "PropTestEnum_with_export",
   proc (self: PropTestNode): PropTestEnum = self.PropTestEnum_with_export,

--- a/testproject/editor/nim/src/classes/gdproptestnode_pragmas.nim
+++ b/testproject/editor/nim/src/classes/gdproptestnode_pragmas.nim
@@ -54,7 +54,7 @@ MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT"""
   node_ref* {.gdexport.}: Node
   node_path* {.gdexport(Appearance.nodePath("Node2D", "Node3D")).}: NodePath
 
-PropTestNodePragmas.registerEnum PropTestPragmasEnum
+PropTestNodePragmas.bind PropTestPragmasEnum
 
 method onInit(self: PropTestNodePragmas) =
   self.StringArray_with_export_multiline = typedArray[String](1)

--- a/testproject/runtime/nim/src/classes/gdextnode/enums.nim
+++ b/testproject/runtime/nim/src/classes/gdextnode/enums.nim
@@ -22,9 +22,9 @@ type TestFlags = enum
   Flag5
 
 
-GDExtNode.registerEnum TestEnumA
-GDExtNode.registerEnum TestEnumB
-GDExtNode.registerBitField TestFlags
+GDExtNode.bind TestEnumA
+GDExtNode.bind TestEnumB
+GDExtNode.bind set[TestFlags]
 
 var testEnumA: TestEnumA = EnumA2
 var testEnumB: TestEnumB = EnumB2


### PR DESCRIPTION
Removed registerEnum and registerBitField functions and replaced them with bind functions: passing enum to bind will register it as an enum, and passing set[enum] will register it as a bitfield.

Example:
```nim
import gdext

type
  MyNode {.gdsync.} = ptr object of Node
    testEnum* {.gdexport.}: TestEnum = Enum2
    testFlags* {.gdexport.}: set[TestFlags] = {Flag2}

  TestEnum = enum
    Enum1 
    Enum2 = 2
    Enum3

  TestFlags = enum # Values in Godot:
    Flag1     # => 1
    Flag2 = 2 # => 4
    Flag3     # => 8
    Flag4     # => 16
    Flag5     # => 32

MyNode.bind TestEnum
MyNode.bind set[TestFlags]
```