### PR TITLE
Feat: Pretty up the appearance of enums and sets in the editor inspecor.

### DIFF
--- a/src/gdext/core/userclass/propertyinfo.nim
+++ b/src/gdext/core/userclass/propertyinfo.nim
@@ -10,7 +10,9 @@ import gdext/gen/globalenums except VariantType
 type
   GodotEnumMeta* = object
     className*: StringName
-proc Meta*[T: enum](_: typedesc[T]): var GodotEnumMeta =
+    hintString*: String
+
+proc Meta*[T: enum](_: typedesc[T|set[T]]): var GodotEnumMeta =
   var instance {.global.} : GodotEnumMeta
   instance
 

--- a/testproject/editor/nim/src/classes/gdproptestnode.nim
+++ b/testproject/editor/nim/src/classes/gdproptestnode.nim
@@ -5,11 +5,14 @@ import gdext/classes/[
 ]
 
 type PropTestEnum* = enum
-  PropTestEnum1, PropTestEnum2, PropTestEnum3
+  PropTestEnum1, PropTestEnum2 = 10, PropTestEnum3
+type PropTestFlags* = enum
+  PropTestFlag1, PropTestFlag2 = 10, PropTestFlag3
 
 type PropTestNode* {.gdsync, initlevel: Initialization_Scene.} = ptr object of Node
   icon*: gdref Texture2D
   PropTestEnum_with_export*: PropTestEnum
+  PropTestFlags_with_export*: set[PropTestFlags]
   string_with_export*: string = "with export"
   string_with_export_placeholder*: string
   string_with_export_dir*: string = "res://nim"
@@ -52,10 +55,15 @@ gdexport "icon",
   proc (self: PropTestNode; value: gdref Texture2D) = self.icon = value
 
 PropTestNode.bind PropTestEnum
+PropTestNode.bind set[PropTestFlags]
 
 gdexport "PropTestEnum_with_export",
   proc (self: PropTestNode): PropTestEnum = self.PropTestEnum_with_export,
   proc (self: PropTestNode; value: PropTestEnum) = self.PropTestEnum_with_export = value
+
+gdexport "PropTestFlags_with_export",
+  proc (self: PropTestNode): set[PropTestFlags] = self.PropTestFlags_with_export,
+  proc (self: PropTestNode; value: set[PropTestFlags]) = self.PropTestFlags_with_export = value
 
 gdexport "string_with_export",
   proc (self: PropTestNode): string = self.string_with_export,

--- a/testproject/runtime/nim/src/classes/gdextnode/enums.nim
+++ b/testproject/runtime/nim/src/classes/gdextnode/enums.nim
@@ -16,7 +16,7 @@ type TestEnumB = enum
 
 type TestFlags = enum
   Flag1
-  Flag2
+  Flag2 = 3
   Flag3
   Flag4
   Flag5


### PR DESCRIPTION
When you gdexport an enum or set[enum], what you see in the inspector so far is just a number.
This PR generates a hint string when registering a property so that it will be displayed in the inspector in the proper form.

Example:

```nim
import gdext

type
  PropTestNode* {.gdsync.} = ptr object of Node
    propTestFlags* {.gdexport.}: set[PropTestFlags]
    propTestEnum* {.gdexport.}: PropTestEnum

  PropTestFlags* = enum
    PropTestFlag1, PropTestFlag2 = 10, PropTestFlag3
  PropTestEnum* = enum
    PropTestEnum1, PropTestEnum2 = 10, PropTestEnum3

PropTestNode.bind set[PropTestFlags]
PropTestNode.bind PropTestEnum
```

![image](https://github.com/user-attachments/assets/83065380-5cd5-447b-9af8-85fe0ad36ac1)
