### PR TITLE
Feat: Improve error messages when attempting to override undefined methods.

### DIFF
--- a/src/gdext/core/userclass/virtuals.nim
+++ b/src/gdext/core/userclass/virtuals.nim
@@ -45,7 +45,16 @@ proc emitterdef(middle: MiddleExp; procdef: NimNode): NimNode =
       return
 
 proc callwithEmitter*(procdef: NimNode): NimNode =
-  ident($procdef.name & "_emit").newCall(procdef.params[1..^1].mapIt(it[0])).add(procdef.body)
+
+  let emitter = ident($procdef.name & "_emit")
+  let call = emitter.newCall(procdef.params[1..^1].mapIt(it[0])).add(procdef.body)
+  let errormsg = newlit "The " & $procdef.name & " method of the parent class cannot be called. Verify that the method exists, that the name is correct, and that the class module declaring the method is imported."
+  let error = bindSym"lineerror".newCall(errormsg, procdef.name)
+  quote do:
+    when compiles(`call`):
+      `call`
+    else:
+      `error`
 
 proc sync_virtualDef*(procdef: NimNode): NimNode =
   var middle = parseMiddle procdef

--- a/src/gdext/surface/userclass.nim
+++ b/src/gdext/surface/userclass.nim
@@ -137,6 +137,9 @@ macro gdsync*(body): untyped =
     if body.body.kind == nnkEmpty: # forward declaration
       hint "{.gdsync.} is not required for forward declarations.", body
       body
+    elif body.name.eqIdent "onInit": # forward declaration
+      hint "{.gdsync.} is not required for onInit.", body
+      body
     elif body.hasPragma("base"):
       sync_virtualDef(body)
     else:


### PR DESCRIPTION
To clarify the error displayed when trying to override an undefined (or unimported) virtual method with {.gdsync.}.

```nim
import gdext
import gdext/classes/gdObject

type TestObject* = ptr object of Object


method ready*(self: TestObject) {.gdsync.} = discard
```
```terminal
Error: The ready method of the parent class cannot be called. Verify that the method exists, that the
name is correct, and that the class module declaring the method is imported.
```