### PR TITLE
fix(gdext): stop over-retaining RefCounted when boxing GdRef into Variant (#345)

### DIFF
--- a/src/gdext/private/typeshift.nim
+++ b/src/gdext/private/typeshift.nim
@@ -147,7 +147,6 @@ proc encode*[T: RefCounted](v: GdRef[T]; p: pointer) =
 proc decode*[T: RefCounted](p: pointer; Result: typedesc[GdRef[T]]): Result =
   p.decode(T).referenced
 proc variant*[T: RefCounted](v: GdRef[T]): Variant =
-  discard hook_reference v.handle.engineInstance
   v.handle.variant
 proc get*[T: RefCounted](v: Variant; Result: typedesc[GdRef[T]]): Result =
   v.get(T).referenced


### PR DESCRIPTION
Fixes #345

## Problem
Reading an exported `GdRef[RefCounted]` property repeatedly leaks the object. The same leak occurs on internal `GdRef` <-> `Variant` round-trips.

## Cause
When marshalling a `GdRef[T]` into a `Variant` to hand back to the engine, `typeshift.nim` unconditionally calls `hook_reference` (an extra `RefCounted.reference()`). Godot's `Variant` already owns a reference when it stores a boxed RefCounted (`Variant::ObjData` mirrors `Ref<T>`), so this extra retain is never balanced and leaks.

## Change
Remove the extra retain from the `GdRef` -> `Variant` box:

```nim
proc variant*[T: RefCounted](v: GdRef[T]): Variant =
  v.handle.variant          # was: discard hook_reference v.handle.engineInstance; ...
```

## Why PR #346 does not fix this
#346 removes the retain from this `GdRef` box but **re-adds the same `+1`** inside the raw `Object` -> `Variant` box (`when T is RefCounted: discard hook_reference v.engineInstance`). Because the `GdRef` box ultimately calls that `Object` box, the net retain is unchanged and the leak persists.

## Verification (headless, Godot 4.7)
A minimal extension with an exported `GdRef[Texture2D]` property was driven from GDScript, then the property was released and the node freed before exit. Godot's `resources still in use at exit` / `ObjectDB instances leaked` reports:

| path | before | after |
|---|---|---|
| property getter read (400x) | leaks | clean |
| property setter write (400x) | leaks | clean |
| 100k internal `variant`<->`get` round-trips | leaks | clean |
| GDScript holds the object after the Nim side releases it | - | clean (no under-retention / no freed-object use) |

Repro project (headless `LEAKMODE=read`): pending/available on request.