### PR TITLE
fix(gdext): RefCounted args to engine methods must carry an owned reference

### DIFF
--- a/src/gdext/private/gdinterface.nim
+++ b/src/gdext/private/gdinterface.nim
@@ -34,6 +34,7 @@ template getPtr*(v: Variant): pointer = cast[pointer](addr v)
 template getPtr*[T: Object](v: T): pointer =
   cast[pointer](v.engineInstancePtr)
 template getPtr*(v: GdRef): pointer =
+  discard hook_reference v.handle.engineInstance
   getPtr v.handle
 proc getPtr*[I](arr: array[I, Variant]): array[I, pointer] =
   for i in 0..<arr.len:


### PR DESCRIPTION
Companion to #355 (which fixes the #345 over-retain leak on the return/Variant box). This fixes the opposite direction: RefCounted **arguments** passed to engine methods that store the object (e.g. `MeshInstance3D.set_mesh(...)`) are under-retained, causing a use-after-free.

## Repro (deterministic, headless)
In a small Godot scene, call a Nim function that creates a `MeshInstance3D`, sets an `ImmediateMesh` via `set_mesh`, and returns the Node:

```
back nil?  <ImmediateMesh#...>    # Nim: node.get_mesh() right after set_mesh -> VALID
line.mesh = <Object#null>         # GDScript reads .mesh -> NULL (mesh already freed)
SIGSEGV                            # crash (also crashes on add_child)
```

A bare Node return (no mesh) is clean, so this is specific to the RefCounted stored into the Object.

## Root cause
`set_mesh` is generated as `methodbind.ptrcall(self, [getPtr mesh])`, and `getPtr(GdRef)` returned a **borrowed `Object*`** (`cast[pointer](handle.engineInstance)`). For RefCounted method arguments the extension is expected to hand an owned reference which the engine consumes/stores. With a borrowed pointer the engine never retains the object, so it is destroyed the instant the extension-side `GdRef`s go out of scope -> premature free / use-after-free.

## Fix
Establish an owned reference before passing the argument:

```nim
template getPtr*(v: GdRef): pointer =
  discard hook_reference v.handle.engineInstance
  getPtr v.handle
```

## Verification
Headless, Godot 4.7:
- before: `line.mesh` reads null, SIGSEGV (and `add_child` crashes);
- after: `line.mesh` reads valid, no crash, stable across frames;
- no new leaks in the driver, and the combined fix (net-0 + this) is clean (0 leaks, 0 crashes) on the #345 read/write/holdfree scenarios.

This balances the RefCounted refcount in both directions (over-retain on return boxing, under-retain on method args). Happy to package the exact driver scene and build steps.
